### PR TITLE
Feat submenu

### DIFF
--- a/App/BitBar/BitBar-Info.plist
+++ b/App/BitBar/BitBar-Info.plist
@@ -34,5 +34,10 @@
 	<string>App</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 </dict>
 </plist>

--- a/App/BitBar/Plugin.h
+++ b/App/BitBar/Plugin.h
@@ -20,6 +20,8 @@
 @property (nonatomic)       NSNumber *refreshIntervalSeconds;
 @property (nonatomic)     NSMenuItem *lastUpdatedMenuItem;
 @property (nonatomic)         NSDate *lastUpdated;
+@property (nonatomic)         NSMutableDictionary *imageCache;
+
 @property (readonly)   PluginManager *manager;
 
 // UI

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -54,6 +54,11 @@
         item.image = image;
     }
     
+    
+    if (params[@"tooltip"]) {
+        [item setToolTip:[params objectForKey:@"tooltip"]];
+    }
+    
     if (params[@"submenu"]) {
         NSMenu *submenu = [[NSMenu alloc] init];
         [item setSubmenu:submenu];

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -41,9 +41,27 @@
     item.representedObject = params;
     [item setTarget:self];
   }
-  if (params[@"size"] || params[@"color"])
-    item.attributedTitle = [self attributedTitleWithParams:params];
+    if (params[@"size"] || params[@"color"]) {
+        item.attributedTitle = [self attributedTitleWithParams:params];
+    }
 
+    
+    if (params[@"submenu"]) {
+        NSMenu *submenu = [[NSMenu alloc] init];
+        [item setSubmenu:submenu];
+        
+        NSArray * menuItems = [params objectForKey:@"submenu"];
+    
+        
+        if ([menuItems isKindOfClass:[NSArray class]]) {
+        
+            for (NSDictionary* dictMenuItem in menuItems) {
+                [submenu addItem:[self buildMenuItemWithParams:dictMenuItem]];
+            }
+        }
+    }
+    
+    
   return item;
 }
 
@@ -62,7 +80,9 @@
   return attributedTitle;
 }
 
-- (NSMenuItem*) buildMenuItemForLine:(NSString *)line { return [self buildMenuItemWithParams:[self dictionaryForLine:line]]; }
+- (NSMenuItem*) buildMenuItemForLine:(NSString *)line {
+    return [self buildMenuItemWithParams:[self dictionaryForLine:line]];
+}
 
 
 - (NSDictionary*) jsonDictionaryForLine:(NSString *)line {

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -16,9 +16,16 @@
 
 @implementation Plugin
 
-- init { return self = super.init ? _currentLine = -1, _cycleLinesIntervalSeconds = 5, self : nil; }
+- init {
+    
+    self.imageCache = [[NSMutableDictionary alloc] init];
+    
+    return self = super.init ? _currentLine = -1, _cycleLinesIntervalSeconds = 5, self : nil;
+}
 
-- initWithManager:(PluginManager*)manager { return self = self.init ? _manager = manager, self : nil; }
+- initWithManager:(PluginManager*)manager {
+    return self = self.init ? _manager = manager, self : nil;
+}
 
 - (NSStatusItem *)statusItem { return _statusItem = _statusItem ?: ({
     
@@ -47,11 +54,7 @@
 
     
     if (params[@"image"]) {
-        NSURL * imageUrl = [NSURL URLWithString:[params objectForKey:@"image"]];
-                 
-        NSImage * image = [[NSImage alloc] initWithContentsOfURL:imageUrl];
-        
-        item.image = image;
+        item.image = [self getImageForUrl:[params objectForKey:@"image"]];
     }
     
     
@@ -81,6 +84,21 @@
     
     
   return item;
+}
+
+- (NSImage *) getImageForUrl:(NSString * ) imageUrl {
+    
+    if (!self.imageCache[imageUrl]) {
+        NSURL * url = [NSURL URLWithString:imageUrl];
+        
+        NSImage * image = [[NSImage alloc] initWithContentsOfURL:url];
+        
+        self.imageCache[imageUrl] = image;
+
+    }
+
+    return [self.imageCache objectForKey:imageUrl];
+
 }
 
 - (NSAttributedString*) attributedTitleWithParams:(NSDictionary *)params {

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -144,7 +144,8 @@
            *param3 = params[@"param3"] ?: @"",
            *param4 = params[@"param4"] ?: @"",
            *param5 = params[@"param5"] ?: @"",
-         *terminal = params[@"terminal"] ?: [NSString stringWithFormat:@"%s", "true"];
+         *terminal = params[@"terminal"] ?: [NSString stringWithFormat:@"%s", "true"],
+             *removeOnSuccess = params[@"removeOnSuccess"] ?: [NSString stringWithFormat:@"%s", "false"];
     NSArray *args = params[@"args"] ?: ({
 
       NSMutableArray *argArray = @[].mutableCopy;
@@ -161,11 +162,21 @@
       NSLog(@"Args: %@", args);
 
       id task = [params[@"root"] isEqualToString:@"true"] ? STPrivilegedTask.new : NSTask.new;
+       NSTask* tTask = (NSTask*) task;
+      [tTask setLaunchPath:bash];
+      [tTask setArguments:args];
 
-      [(NSTask*)task setLaunchPath:bash];
-      [(NSTask*)task setArguments:args];
-      [(NSTask*)task launch];
-
+        [tTask setTerminationHandler:^(NSTask *aTask){
+            if ([aTask terminationStatus] == 0) {
+                if ([removeOnSuccess isEqual: @"true"]) {
+                    [[menuItem menu] removeItem:menuItem];
+                }
+            } else {
+                [menuItem setImage:[NSImage imageNamed:NSImageNameCaution]];
+            }
+        }];
+        
+        [tTask launch];
     } else {
 
       NSString *full_link = [NSString stringWithFormat:@"%@ %@ %@ %@ %@ %@", bash, param1, param2, param3, param4, param5];

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -46,6 +46,14 @@
     }
 
     
+    if (params[@"image"]) {
+        NSURL * imageUrl = [NSURL URLWithString:[params objectForKey:@"image"]];
+                 
+        NSImage * image = [[NSImage alloc] initWithContentsOfURL:imageUrl];
+        
+        item.image = image;
+    }
+    
     if (params[@"submenu"]) {
         NSMenu *submenu = [[NSMenu alloc] init];
         [item setSubmenu:submenu];
@@ -91,7 +99,6 @@
                             JSONObjectWithData:[line dataUsingEncoding:NSUTF8StringEncoding]
                             options:kNilOptions
                             error:&error];
-    
     
     return params;
 }

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -64,7 +64,12 @@
         if ([menuItems isKindOfClass:[NSArray class]]) {
         
             for (NSDictionary* dictMenuItem in menuItems) {
-                [submenu addItem:[self buildMenuItemWithParams:dictMenuItem]];
+                
+                if (dictMenuItem && dictMenuItem[@"title"]) {
+                    [submenu addItem:[self buildMenuItemWithParams:dictMenuItem]];
+                } else {
+                    [submenu addItem:[NSMenuItem separatorItem]];
+                }
             }
         }
     }

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -64,8 +64,27 @@
 
 - (NSMenuItem*) buildMenuItemForLine:(NSString *)line { return [self buildMenuItemWithParams:[self dictionaryForLine:line]]; }
 
+
+- (NSDictionary*) jsonDictionaryForLine:(NSString *)line {
+    NSError* error;
+    NSDictionary* params = [NSJSONSerialization
+                            JSONObjectWithData:[line dataUsingEncoding:NSUTF8StringEncoding]
+                            options:kNilOptions
+                            error:&error];
+    
+    
+    return params;
+}
+
+
 - (NSDictionary*) dictionaryForLine:(NSString *)line {
 
+    NSDictionary* jsonParams = [self jsonDictionaryForLine:line];
+    
+    if (jsonParams && jsonParams[@"title"]) {
+        return jsonParams;
+    }
+    
   NSRange found = [line rangeOfString:@"|"];
   if (found.location == NSNotFound) return @{ @"title": line };
 


### PR DESCRIPTION
Hi,

first to say. BitBar is very cool and I like it a lot. I modified it a bit to have submenus. A big change is that it supports JSON as a line format. With this it was very easy to implement submenus
this a example row from a shell script:

```bash
echo '{"title":"SH","submenu":[{"title":"Oh Yeah"}]}'
````
every of the old parameters can used as json keys.

there are also some new parameters

- image --- a url of a image
- removeOnSuccess --- true removes the menu item after success of the shell script.

An other change is that a caution symbol appears, when a script terminates with exit status != 0

if you have questions feel free to contact me.

