### PR TITLE
Fix to how |bash=<path> expressions are parsed when path contains whitespace

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -72,6 +72,8 @@
   NSString * title = [[line substringToIndex:found.location] stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
   NSMutableDictionary * params = @{@"title":title}.mutableCopy;
   NSString * paramsStr = [line substringFromIndex:found.location + found.length];
+    
+  NSString  * prevKey;
   for (NSString * paramStr in [[paramsStr stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet]
                                      componentsSeparatedByCharactersInSet:NSCharacterSet.whitespaceCharacterSet]) {
     NSRange found = [paramStr rangeOfString:@"="];
@@ -85,6 +87,14 @@
         value = [paramStr substringFromIndex:found.location + found.length];
       }
       params[key] = value;
+      prevKey = key;
+    }
+    else {    //no = in the string, concat it onto previous one (if there was a previous one)
+        if (prevKey != nil && [params objectForKey:prevKey]) {
+            params[prevKey] = [NSString stringWithFormat:@"%@ %@", params[prevKey], paramStr];
+        } else {
+            NSLog(@"Unexpected gobbleygook in variable assignment: %@", paramStr);
+        }
     }
   }
   return params;


### PR DESCRIPTION
I wanted to run the jtokoph's Spotify plugin, but unfortunately it didn't work when the plugin was in a directory with whitespace. I decided it would be too much work to rename the directory, so I spent a few orders of magnitude more time editing the code. As far as I know this doesn't break anything (are there ever legitimate words after the pipe that don't have an equal sign?), so hopefully this fix will save other folks more time than it saved me.