### PR TITLE
Additional features (refresh keyword, better parameter passing, terminal window bug fix)

### DIFF
--- a/App/BitBar/ExecutablePlugin.h
+++ b/App/BitBar/ExecutablePlugin.h
@@ -11,6 +11,7 @@
 @interface ExecutablePlugin : Plugin
 
 @property (nonatomic, strong) NSTimer *lineCycleTimer;
+@property (nonatomic, strong) NSTimer *refreshTimer;
 
 - (BOOL) refreshContentByExecutingCommand;
 

--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -51,7 +51,10 @@
   // success
   self.lastCommandWasError = NO;
   return YES;
-  
+}
+
+-(void)performRefreshNow:(NSMenuItem*)menuItem{
+  [self refresh];
 }
 
 -(BOOL)refresh {
@@ -59,6 +62,8 @@
   
   [self.lineCycleTimer invalidate];
   self.lineCycleTimer = nil;
+  [self.refreshTimer invalidate];
+  self.refreshTimer = nil;
   
   // execute command
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,0),  ^{
@@ -87,7 +92,7 @@
       [self.manager pluginDidUdpdateItself:self];
       
       // schedule next refresh
-      [NSTimer scheduledTimerWithTimeInterval:[self.refreshIntervalSeconds doubleValue] target:self selector:@selector(refresh) userInfo:nil repeats:NO];
+      _refreshTimer = [NSTimer scheduledTimerWithTimeInterval:[self.refreshIntervalSeconds doubleValue] target:self selector:@selector(refresh) userInfo:nil repeats:NO];
       
     });
   });

--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -58,12 +58,14 @@
 }
 
 -(BOOL)refresh {
-  
-  
   [self.lineCycleTimer invalidate];
   self.lineCycleTimer = nil;
   [self.refreshTimer invalidate];
   self.refreshTimer = nil;
+  
+  self.content = @"Updating ...";
+  self.errorContent = @"";
+  [self rebuildMenuForStatusItem:self.statusItem];
   
   // execute command
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,0),  ^{

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -314,9 +314,15 @@
 }
 
 - (NSString *)allContent {
-
-  return _allContent = _allContent ?: [self.errorContent length] > 0 ? [self.content stringByAppendingString:self.errorContent]
-                                                                     : self.content;
+  if (!_allContent) {
+    _allContent = self.content;
+    if (self.errorContent.length > 0) {
+      _allContent = [@"⚠️" stringByAppendingString:_allContent];
+      _allContent = [_allContent stringByAppendingString:@"\n---\n"];
+      _allContent = [_allContent stringByAppendingString:self.errorContent];
+    }
+  }
+  return _allContent;
 }
 
 - (NSArray *)allContentLines {

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -34,7 +34,9 @@
 
   NSString * title = [params objectForKey:@"title"];
   SEL sel = params[@"href"] ? @selector(performMenuItemHREFAction:)
-          : params[@"bash"] ? @selector(performMenuItemOpenTerminalAction:) : nil;
+          : params[@"bash"] ? @selector(performMenuItemOpenTerminalAction:)
+          : params[@"refresh"] ? @selector(performRefreshNow:):
+    nil;
 
   NSMenuItem * item = [NSMenuItem.alloc initWithTitle:title action:sel keyEquivalent:@""];
   if (sel) {
@@ -98,6 +100,10 @@
     }
   }
   return params;
+}
+
+-(void)performRefreshNow:(NSMenuItem*)menuItem {
+    NSLog(@"Nothing to refresh in this plugin");
 }
 
 - (void) performMenuItemHREFAction:(NSMenuItem *)menuItem {

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -37,7 +37,7 @@
           : params[@"bash"] ? @selector(performMenuItemOpenTerminalAction:)
           : params[@"refresh"] ? @selector(performRefreshNow:):
     nil;
-
+  
   NSMenuItem * item = [NSMenuItem.alloc initWithTitle:title action:sel keyEquivalent:@""];
   if (sel) {
     item.representedObject = params;
@@ -145,16 +145,13 @@
       [(NSTask*)task setLaunchPath:bash];
       [(NSTask*)task setArguments:args];
       [(NSTask*)task launch];
-
+      
     } else {
 
       NSString *full_link = [NSString stringWithFormat:@"%@ %@ %@ %@ %@ %@", bash, param1, param2, param3, param4, param5];
       NSString *s = [NSString stringWithFormat:@"tell application \"Terminal\" \n\
+                do script \"%@\"\n\
                  activate \n\
-                 if length of (get every window) is 0 then \n\
-                 tell application \"System Events\" to tell process \"Terminal\" to click menu item \"New Window\" of menu \"File\" of menu bar 1 \n\
-                 end if \n\
-                 do script \"%@\" in front window activate \n\
                  end tell", full_link];
       NSAppleScript *as = [NSAppleScript.alloc initWithSource: s];
       [as executeAndReturnError:nil];

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -67,38 +67,41 @@
 - (NSMenuItem*) buildMenuItemForLine:(NSString *)line { return [self buildMenuItemWithParams:[self dictionaryForLine:line]]; }
 
 - (NSDictionary*) dictionaryForLine:(NSString *)line {
-
+  // Find the title
   NSRange found = [line rangeOfString:@"|"];
   if (found.location == NSNotFound) return @{ @"title": line };
-
   NSString * title = [[line substringToIndex:found.location] stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
   NSMutableDictionary * params = @{@"title":title}.mutableCopy;
-  NSString * paramsStr = [line substringFromIndex:found.location + found.length];
-    
-  NSString  * prevKey;
-  for (NSString * paramStr in [[paramsStr stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet]
-                                     componentsSeparatedByCharactersInSet:NSCharacterSet.whitespaceCharacterSet]) {
-    NSRange found = [paramStr rangeOfString:@"="];
-    if (found.location != NSNotFound) {
-      NSString * key = [paramStr substringToIndex:found.location].lowercaseString;
+  
+  // Find the parameters
+  NSString * paramStr = [line substringFromIndex:found.location + found.length];
 
-      id value;
-      if ([key isEqualToString:@"args"]) {
-        value = [[paramStr substringFromIndex:found.location + found.length] componentsSeparatedByString:@"__"];
-       } else {
-        value = [paramStr substringFromIndex:found.location + found.length];
-      }
-      params[key] = value;
-      prevKey = key;
+  NSScanner* scanner = [NSScanner scannerWithString:paramStr];
+  NSMutableCharacterSet* keyValueSeparator = [NSMutableCharacterSet characterSetWithCharactersInString:@"=:"];
+  NSMutableCharacterSet* quoteSeparator = [NSMutableCharacterSet characterSetWithCharactersInString:@"\"'"];
+  
+  while (![scanner isAtEnd]) {
+    NSString *key = @""; NSString* value = @"";
+    [scanner scanUpToCharactersFromSet:keyValueSeparator intoString:&key];
+    [scanner scanCharactersFromSet:keyValueSeparator intoString:NULL];
+    
+    if ([scanner scanCharactersFromSet:quoteSeparator intoString:NULL]) {
+      [scanner scanUpToCharactersFromSet:quoteSeparator intoString:&value];
+      [scanner scanCharactersFromSet:quoteSeparator intoString:NULL];
+    } else {
+      [scanner scanUpToString:@" " intoString:&value];
     }
-    else {    //no = in the string, concat it onto previous one (if there was a previous one)
-        if (prevKey != nil && [params objectForKey:prevKey]) {
-            params[prevKey] = [NSString stringWithFormat:@"%@ %@", params[prevKey], paramStr];
-        } else {
-            NSLog(@"Unexpected gobbleygook in variable assignment: %@", paramStr);
-        }
+    
+    // Remove extraneous spaces from key and value
+    key = [key stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    value = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    params[key] = value;
+    
+    if([key isEqualToString:@"args"]){
+      params[key] = [value componentsSeparatedByString:@"__"];
     }
   }
+  
   return params;
 }
 
@@ -349,9 +352,8 @@
 }
 
 - (NSString*) cleanLine:(NSString*)line {
-  
+    return line;
   NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"  +" options:NSRegularExpressionCaseInsensitive error:nil];
-  line = [line stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
   return [regex stringByReplacingMatchesInString:line options:0 range:NSMakeRange(0, line.length) withTemplate:@" "];
 }
 

--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -229,6 +229,10 @@
         plugin = [ExecutablePlugin.alloc initWithManager:self];
       }
       
+      if ([[file substringToIndex:4] isEqualToString:@"off."]) {
+        continue;
+      }
+      
       [plugin setPath:[self.path stringByAppendingPathComponent:file]];
       [plugin setName:file];
       [plugin.statusItem setTitle:@"…"];


### PR DESCRIPTION
Hi !

I'm really interested in this project, and have added a few features that I needed for a few scripts

## Refresh keyword
Adding the keyword `refresh` after the `|` adds an action to the menu item. Upon clicking this button, the plugin will be refreshed immediately.

## Better parameter passing
The logic for parsing the parameter string felt a bit weak and prevented passing path containing spaces (or including small bash scripts inline)

I've refactored the way parameters are scanned using an NSScanner, which should be a bit more legible and robust. The legacy behaviour is kept, but this kind of lines are now possible

`Say something | bash="say Hello world"`
`Say something else | bash:'say Goodbye moon;exit' terminal=true`

## Terminal window management

Launching a `bash` script by clicking a button failed when the frontmost terminal window was already running. I've changed the AppleScript to make sure to run the script in a new terminal window if `terminal=true`.
We might also include a keyword to close this window if the script returned a `no error (0)` status code

Let me know if you'd prefer multiple pull request