### PR TITLE
Add Bitstamp last BTC price plugin

### DIFF
--- a/Plugins/Bitcoin/bitstamp.net/last.10s.sh
+++ b/Plugins/Bitcoin/bitstamp.net/last.10s.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Bitstamp rate
+# BitBar plugin
+#
+# by Damien Lajarretie
+# Based on Coinbase bitbar plugin by Mat Ryer
+#
+# Shows last BTC price (in USD) on Bitstamp exchange.
+#
+
+echo -n "Bitstamp: $"; curl -s "https://www.bitstamp.net/api/ticker/" | egrep -o '"last": "[0-9]+(\.)?([0-9]{0,2}")?' | sed 's/"last": //' | sed 's/\"//g'


### PR DESCRIPTION
I just added a script based on the Coinbase plugin to show bitstamp last BTC price instead :) :chart_with_upwards_trend: :rocket: :moon: 