### PR TITLE
bandwidth plugin

### DIFF
--- a/Plugins/Network/bandwidth.1s.sh
+++ b/Plugins/Network/bandwidth.1s.sh
@@ -8,12 +8,12 @@
 # Depends on ifstat (brew install-able)
 
 export PATH="/usr/local/bin:${PATH}"
-INTERFACES=$(node -e 'process.stdout.write(Object.keys(require("os").networkInterfaces()).join(" "));')
+INTERFACES=$(ifconfig -lu)
 
-echo "▲ $(ifstat -n -w -i en0 0.1 1 | tail -n 1 | awk '{print $1, " - ", $2;}') ▼"
+echo "▼ $(ifstat -n -w -i en0 0.1 1 | tail -n 1 | awk '{print $1, " - ", $2;}') ▲"
 echo "---"
 for INTERFACE in ${INTERFACES}; do
   if [[ ${INTERFACE} != "en0" ]]; then
-    echo "${INTERFACE}: ▲ $(ifstat -n -w -i ${INTERFACE} 0.1 1 | tail -n 1 | awk '{print $1, " - ", $2;}') ▼"
+    echo "${INTERFACE}: ▼ $(ifstat -n -w -i ${INTERFACE} 0.1 1 | tail -n 1 | awk '{print $1, " - ", $2;}') ▲"
   fi
 done

--- a/Plugins/Network/bandwidth.1s.sh
+++ b/Plugins/Network/bandwidth.1s.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# bandwidth
+# BitBar plugin
+#
+# by Ant Cosentino <ant@io.co.za>
+# Gets up/down (kilobytes per second) across available network interfaces.
+# Depends on ifstat (brew install-able)
+
+export PATH="/usr/local/bin:${PATH}"
+INTERFACES=$(node -e 'process.stdout.write(Object.keys(require("os").networkInterfaces()).join(" "));')
+
+echo "▲ $(ifstat -n -w -i en0 0.1 1 | tail -n 1 | awk '{print $1, " - ", $2;}') ▼"
+echo "---"
+for INTERFACE in ${INTERFACES}; do
+  if [[ ${INTERFACE} != "en0" ]]; then
+    echo "${INTERFACE}: ▲ $(ifstat -n -w -i ${INTERFACE} 0.1 1 | tail -n 1 | awk '{print $1, " - ", $2;}') ▼"
+  fi
+done


### PR DESCRIPTION
are plugins that rely on a dependency that's unavailable by default ruled out for inclusion in the project? if so, this one's a no-go. this depends on ifstat, which is brew installable.