### PR TITLE
Refresh keyword

### DIFF
--- a/App/BitBar/ExecutablePlugin.h
+++ b/App/BitBar/ExecutablePlugin.h
@@ -11,6 +11,7 @@
 @interface ExecutablePlugin : Plugin
 
 @property (nonatomic, strong) NSTimer *lineCycleTimer;
+@property (nonatomic, strong) NSTimer *refreshTimer;
 
 - (BOOL) refreshContentByExecutingCommand;
 

--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -57,6 +57,12 @@
 }
 
 -(void)performRefreshNow:(NSMenuItem*)menuItem{
+  self.content = @"Updating ...";
+  self.errorContent = @"";
+  [self rebuildMenuForStatusItem:self.statusItem];
+  self.currentLine = -1;
+  [self cycleLines];
+  [self.manager pluginDidUdpdateItself:self];
   [self refresh];
 }
 
@@ -65,11 +71,7 @@
   self.lineCycleTimer = nil;
   [self.refreshTimer invalidate];
   self.refreshTimer = nil;
-  
-  self.content = @"Updating ...";
-  self.errorContent = @"";
-  [self rebuildMenuForStatusItem:self.statusItem];
-  
+    
   // execute command
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,0),  ^{
     [self refreshContentByExecutingCommand];

--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -54,7 +54,10 @@
   // success
   self.lastCommandWasError = NO;
   return YES;
-  
+}
+
+-(void)performRefreshNow:(NSMenuItem*)menuItem{
+  [self refresh];
 }
 
 -(BOOL)refresh {
@@ -62,6 +65,8 @@
   
   [self.lineCycleTimer invalidate];
   self.lineCycleTimer = nil;
+  [self.refreshTimer invalidate];
+  self.refreshTimer = nil;
   
   // execute command
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,0),  ^{
@@ -90,7 +95,7 @@
       [self.manager pluginDidUdpdateItself:self];
       
       // schedule next refresh
-      [NSTimer scheduledTimerWithTimeInterval:[self.refreshIntervalSeconds doubleValue] target:self selector:@selector(refresh) userInfo:nil repeats:NO];
+      _refreshTimer = [NSTimer scheduledTimerWithTimeInterval:[self.refreshIntervalSeconds doubleValue] target:self selector:@selector(refresh) userInfo:nil repeats:NO];
       
     });
   });

--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -61,12 +61,14 @@
 }
 
 -(BOOL)refresh {
-  
-  
   [self.lineCycleTimer invalidate];
   self.lineCycleTimer = nil;
   [self.refreshTimer invalidate];
   self.refreshTimer = nil;
+  
+  self.content = @"Updating ...";
+  self.errorContent = @"";
+  [self rebuildMenuForStatusItem:self.statusItem];
   
   // execute command
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,0),  ^{

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -34,7 +34,9 @@
 
   NSString * title = [params objectForKey:@"title"];
   SEL sel = params[@"href"] ? @selector(performMenuItemHREFAction:)
-          : params[@"bash"] ? @selector(performMenuItemOpenTerminalAction:) : nil;
+          : params[@"bash"] ? @selector(performMenuItemOpenTerminalAction:)
+          : params[@"refresh"] ? @selector(performRefreshNow:):
+    nil;
 
   NSMenuItem * item = [NSMenuItem.alloc initWithTitle:title action:sel keyEquivalent:@""];
   if (sel) {
@@ -101,6 +103,10 @@
   }
   
   return params;
+}
+
+-(void)performRefreshNow:(NSMenuItem*)menuItem {
+    NSLog(@"Nothing to refresh in this plugin");
 }
 
 - (void) performMenuItemHREFAction:(NSMenuItem *)menuItem {

--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -98,6 +98,7 @@ If you want to contribute, please send us a pull request and we'll add it to our
     * `size=..` to change their text size. eg. `size=12`
     * `bash=..` to make the dropdown run a given script terminal with your script e.g. `bash="/Users/user/BitBar_Plugins/scripts/nginx.restart.sh --verbose"`
     * `terminal=..` if need to start bash script without open Terminal may be true or false
+    * `refresh=..` to make the dropdown items refresh the plugin it belongs to
   * If you're writing scripts, ensure it has a shebang at the top.
   * You can add to `PATH` by including something like `export PATH='/usr/local/bin:/usr/bin:$PATH'` in your plugin script.
 


### PR DESCRIPTION
* Added a `refresh` keyword to manually trigger a refresh of a plugin.
* Improved the UI when a plugin is refreshing by displaying the short string `"Updating ..."` in place of the (now out of date) plugin information.
* Updated the documentation to reflect those changes

In the code, I now keep a reference to the timer triggering the next automatic refresh, invalidating it when a manual refresh is requested.
Before launching a new task, I set the content to `"Updating..."` and manually trigger a menuItem rebuild.
