### PR TITLE
Refactored parameter parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,7 @@ In case you made the mistake of choosing a directory with thousands of files as 
     * `color=..` to change their text color. eg. `color=red` or `color=#ff0000`
     * `font=..` to change their text font. eg. `font=UbuntuMono-Bold`
     * `size=..` to change their text size. eg. `size=12`
-    * `bash=..` to make the dropdown items open terminal with your script e.g. `bash=/Users/user/BitBar_Plugins/scripts/nginx.restart.sh`
-    * `param1=..` if sh script need params
-    * `param2=..` if sh script need params
-    * `param3=..` if sh script need params
+    * `bash=..` to make the dropdown run a given script terminal with your script e.g. `bash="/Users/user/BitBar_Plugins/scripts/nginx.restart.sh --verbose"`
     * `terminal=..` if need to start bash script without open Terminal may be true or false
   * If you're writing scripts, ensure it has a shebang at the top.
 


### PR DESCRIPTION
## Why

The parameter parsing logic felt weak, difficult to read and error-prone to me. I've created a parser that mostly respects the legacy behaviour, adds new feature, and should be easier to maintain and expand in the future.

## Changes

* Using NSScanner to parse key and values
* Now accepting `key="value with space"` syntax
* Now accepting `key:'other value with space'` syntax
* Legacy syntax `key=value` is still accepted
* Updated documentation

## Improvement

This greatly improves the capability of the `bash` keyword. Full scripts can be passed to the plugin. For example :

` Say something | bash="say Hello World"`

To maintain compatibility with existing script, the (now less useful) keywords `param1, param2, ...` are left as is.

## Conflicts and Issues

This removes the possibility introduced in `b2df945`, where the last value of the line could have spaces in it.
I believe the solution in this pull request is cleaner (every param can now have values containing space) with a cleaner implementation.
Updating scripts that uses this feature should not be difficult (wrapping the space separated value in `"` or `'`)