### PR TITLE
Error handling

### DIFF
--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -32,6 +32,9 @@
     [task launch];
   } @catch (NSException *e) {
     NSLog(@"Error when running %@: %@", self.name, e);
+    self.lastCommandWasError = YES;
+    self.content = @"";
+    self.errorContent = e.reason;
     return NO;
   }
   NSData *stdoutData = [[stdoutPipe fileHandleForReading] readDataToEndOfFile];

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -308,9 +308,15 @@
 }
 
 - (NSString *)allContent {
-
-  return _allContent = _allContent ?: [self.errorContent length] > 0 ? [self.content stringByAppendingString:self.errorContent]
-                                                                     : self.content;
+  if (!_allContent) {
+    _allContent = self.content;
+    if (self.errorContent.length > 0) {
+      _allContent = [@"⚠️" stringByAppendingString:_allContent];
+      _allContent = [_allContent stringByAppendingString:@"\n---\n"];
+      _allContent = [_allContent stringByAppendingString:self.errorContent];
+    }
+  }
+  return _allContent;
 }
 
 - (NSArray *)allContentLines {


### PR DESCRIPTION
* Improved error handling UI : When a script return an error, the emoji :warning: is displayed.
    * If the plugin has no content at all, the first line will just contain the :warning: emoji. The error content will be displayed below a separator
    * If the plugin has content, the :warning: emoji will be prepended before the first line of the regular content. The error content will be displayed below a separator
* Displaying NSTasks exception as plugin errors, allowing easier debugging of newly created plugins

The idea is to prevent a verbose error from taking too much place in the status bar by displaying only the :warning: emoji and not cycling through error line.