### PR TITLE
Ignore plugin files that start with "off."

### DIFF
--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -229,6 +229,10 @@
         plugin = [ExecutablePlugin.alloc initWithManager:self];
       }
       
+      if ([[file substringToIndex:4] isEqualToString:@"off."]) {
+        continue;
+      }
+      
       [plugin setPath:[self.path stringByAppendingPathComponent:file]];
       [plugin setName:file];
       [plugin.statusItem setTitle:@"…"];

--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ The refresh time is in the filename of the plugin, following this format:
   * `time` - The refresh rate (see below)
   * `ext` - The file extension
 
+If you'd like to keep a plugin, but prefer not to show it in BitBar, you can prefix the plugin name with `off.`.
+
 For example:
 
   * `date.1m.sh` would refresh every minute.
+  * `off.network.1m.sh` will not be shown in bitbar
 
 Most plugins will come with a default, but you can change it to anything you like:
 


### PR DESCRIPTION
This allows to quickly deactivate files that should be executable, but should not be displayed in bitbar (helper scripts, deprecated plugins, ...)