### PR TITLE
Homebrew plugin: Empty output is counted as 0

### DIFF
--- a/Plugins/Dev/Homebrew/brew-updates.1h.sh
+++ b/Plugins/Dev/Homebrew/brew-updates.1h.sh
@@ -13,7 +13,7 @@ exit_with_error() {
 
 UPDATES=`/usr/local/bin/brew outdated --verbose`;
 
-UPDATE_COUNT=`echo "$UPDATES" | wc -l | sed -e 's/^[[:space:]]*//'`;
+UPDATE_COUNT=`echo "$UPDATES" | grep -v ^$ | wc -l | sed -e 's/^[[:space:]]*//'`;
 
 echo "↑$UPDATE_COUNT"
 echo "---";


### PR DESCRIPTION
It seems as though passing `echo "$UPDATES"` through to `wc -l` can cause wc to count 1 line. Adding `grep -v ^$` strips out any blank line characters, allowing `wc -l` to be given an accurate line count for updates.