### PR TITLE
added iTunes plugin

### DIFF
--- a/Plugins/Music/itunes.10s.sh
+++ b/Plugins/Music/itunes.10s.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Get current iTunes status with play/pause button
+#
+# based on Spotify script by Jason Tokoph (jason@tokoph.net), tweaked by Dan
+# Turkel (daturkel@gmail.com)
+#
+# Shows current track information from iTunes
+# 10 second refresh might be a little too quick. Tweak to your liking.
+
+if [ "$1" = 'launch' ]; then
+  osascript -e 'tell application "iTunes" to activate'
+  exit
+fi
+
+if [ $(osascript -e 'application "iTunes" is running') = "false" ]; then
+  echo "♫"
+  echo "---"
+  echo "iTunes is not running"
+  echo "Launch iTunes | bash=$0 param1=launch terminal=false"
+  exit
+fi
+
+if [ "$1" = 'playpause' ]; then
+  osascript -e 'tell application "iTunes" to playpause'
+  exit
+fi
+
+if [ "$1" = 'previous' ]; then
+  osascript -e 'tell application "iTunes" to previous track'
+  exit
+fi
+
+if [ "$1" = 'next' ]; then
+  osascript -e 'tell application "iTunes" to next track';
+  exit
+fi
+
+state=`osascript -e 'tell application "iTunes" to player state as string'`;
+
+if [ $state = "playing" ]; then
+  state_icon="▶"
+else
+  state_icon="❚❚"
+fi
+
+track=`osascript -e 'tell application "iTunes" to name of current track as string'`;
+artist=`osascript -e 'tell application "iTunes" to artist of current track as string'`;
+album=`osascript -e 'tell application "iTunes" to album of current track as string'`;
+
+echo $state_icon $track - $artist
+echo "---"
+
+case "$0" in
+  *\ * )
+   echo "Your script path | color=#ff0000"
+   echo "($0) | color=#ff0000"
+   echo "has a space in it, which BitBar does not support. | color=#ff0000"
+   echo "Play/Pause/Next/Previous buttons will not work. | color=#ff0000"
+  ;;
+esac
+
+echo Track: $track "| color=#333333"
+echo Artist: $artist "| color=#333333"
+echo Album: $album "| color=#333333"
+
+echo '---'
+
+if [ $state = "playing" ]; then
+  echo "Pause | bash=$0 param1=playpause terminal=false"
+  echo "Previous | bash=$0 param1=previous terminal=false"
+  echo "Next | bash=$0 param1=next terminal=false"
+else
+  echo "Play | bash=$0 param1=playpause terminal=false"
+fi

--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -24,7 +24,8 @@ This repo contains scripts, programs and command-line tools that add functionali
 - Stock tracker
 
 ####Music
-- Spotify (Shows current track information from spotify)
+- iTunes (shows current track information from iTunes)
+- Spotify (Shows current track information from Spotify)
 
 ####Network
 - Bandwidth Usage
@@ -54,7 +55,6 @@ Special thanks to everyone who has contributed:
 - Jason Tokoph - [http://jasontokoph.com](http://jasontokoph.com)
 - Trung Đinh Quang - [https://github.com/trungdq88](https://github.com/trungdq88)
 - Alexandre Espinosa Menor - [https://github.com/alexandregz](https://github.com/alexandregz)
-- Damien Lajarretie - [@dqms_output](https://twitter.com/dqms_output)
 
 ## Write your own
 

--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -55,6 +55,7 @@ Special thanks to everyone who has contributed:
 - Jason Tokoph - [http://jasontokoph.com](http://jasontokoph.com)
 - Trung Đinh Quang - [https://github.com/trungdq88](https://github.com/trungdq88)
 - Alexandre Espinosa Menor - [https://github.com/alexandregz](https://github.com/alexandregz)
+- Dan Turkel - [https://danturkel.com/](https://danturkel.com/)
 
 ## Write your own
 


### PR DESCRIPTION
I took a look at the [lovely Spotify plugin](https://github.com/matryer/bitbar/blob/master/Plugins/Music/spotify.10s.sh) and saw it was implemented in simple AppleScript. I ran a quick find-and-replace to swap out "Spotify" for "iTunes" and tested the functionality—everything still worked! Thus, this plugin duplicates the functionality of the spotify plugin *exactly*. 

Perhaps down the line someone would make one that checks for both iTunes and Spotify status, determines which one is in use, etc. 