### PR TITLE
Added AWS/ELB Plugin

### DIFF
--- a/Plugins/AWS/elb.30s.sh
+++ b/Plugins/AWS/elb.30s.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# Requires: 
+#   awscli (https://aws.amazon.com/cli/)
+#
+# Percentage of healthy EC2 instances behind an ELB
+#   Dropdown with healthy and unhealthy totals
+#
+# Author Jonathan Keith
+
+export PATH='/usr/local/bin:/usr/bin:/bin:$PATH'
+
+## Required Configuration (must provide your own settings here)
+
+# The name of the Elastic Load Balancer
+LOAD_BALANCER=""
+
+# AWS CLI credential profile
+AWS_CLI_PROFILE="default"
+
+## Optional Configuration (not required)
+
+# Prefix label
+MENU_BAR_PREFIX_LABEL="ELB: "
+
+# InService output color (default green)
+IN_SERVICE_COLOR="#29cc00"
+
+# OutOfService output color (default red)
+OUT_SERVICE_COLOR="#ff0033"
+
+## Implementation (changes optional, not required)
+
+if [ -z "$LOAD_BALANCER" ]; then
+  echo "Missing configuration: load balancer name"
+  exit 1
+fi
+
+# Fetch list of instance health statuses (InService or OutOfService)
+status=`aws --profile $AWS_CLI_PROFILE elb describe-instance-health --load-balancer-name $LOAD_BALANCER --query 'InstanceStates[*].[State]' --output text`
+
+# Total number of lines fetched
+total=`echo $status | tr ' ' '\n' | wc -l | xargs`
+
+# Number of lines containing "In" (matches InService lines)
+in=`echo $status | tr ' ' '\n' | grep In | wc -l | xargs`
+
+# Number of lines containing "Out" (matches OutOfService lines)
+out=`echo $status | tr ' ' '\n' | grep Out | wc -l | xargs`
+
+# Percentage calculation
+percent=`bc -l <<< "($in / $total) * 100" | xargs printf "%1.0f"`
+
+# Output
+echo "$MENU_BAR_PREFIX_LABEL $percent%"
+echo "---"
+echo "In: $in | color=$IN_SERVICE_COLOR"
+echo "Out: $out | color=$OUT_SERVICE_COLOR"

--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -14,7 +14,7 @@ This repo contains scripts, programs and command-line tools that add functionali
 ###Available Plugins
 
 ####AWS
-- ELB % in service instances (dropdown with total in/out)
+- ELB (shows percentage of in service instances with total in/out in dropdown)
 
 ####Bitcoin
 - Bitstamp last BTC Price

--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -13,6 +13,9 @@ This repo contains scripts, programs and command-line tools that add functionali
 
 ###Available Plugins
 
+####AWS
+- ELB % in service instances (dropdown with total in/out)
+
 ####Bitcoin
 - Bitstamp last BTC Price
 - Coinbase.com BTC Index
@@ -69,6 +72,7 @@ Special thanks to everyone who has contributed:
 - Chris Tomkins-Tinch - [https://github.com/tomkinsc](https://github.com/tomkinsc)
 - Raemond Bergstrom-Wood - [https://github.com/RaemondBW](https://github.com/RaemondBW)
 - Ant Cosentino - [https://github.com/skibz](https://github.com/skibz)
+- Jonathan Keith - [http://jonkeith.com](http://jonkeith.com) 
 
 ## Write your own
 


### PR DESCRIPTION
Displays the percentage of in service instances attached to a specified Elastic Load Balancer. In service and out of service total are included in the dropdown. Load balancer, AWS CLI profile, menu bar label, and in/out service total colors configurable with bash variables.

![aws-elb-screenshot](https://cloud.githubusercontent.com/assets/1895779/12133694/1cd68fda-b46b-11e5-961d-9992e26abee1.png)
