### PR TITLE
Overload refresh param

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -148,8 +148,17 @@
 
       [(NSTask*)task setLaunchPath:bash];
       [(NSTask*)task setArguments:args];
-      [(NSTask*)task launch];
 
+      if (params[@"refresh"]) {
+          ((NSTask*)task).terminationHandler = ^(NSTask *task) {
+              [self performRefreshNow:NULL];
+          };
+          [(NSTask*)task launch];
+          [(NSTask*)task waitUntilExit];
+      }
+      else {
+        [(NSTask*)task launch];
+      }
     } else {
 
       NSString *full_link = [NSString stringWithFormat:@"%@ %@ %@ %@ %@ %@", bash, param1, param2, param3, param4, param5];


### PR DESCRIPTION
This allows us to tell bitbar to refresh the plugin when a command is finished running.  Useful for (e.g.) reloading the homebrew plugin if you add an "Update all" menu option.

```
echo "Update all | bash=/usr/local/bin/brew param1=upgrade param2=--all terminal=false refresh=true"
```

The overload works as we check for `params[@"bash"]` before we check for `params[@"refresh"]` in [buildMenuItemWithParams](https://github.com/matryer/bitbar/blob/master/App/BitBar/Plugin.m#L40)