### PR TITLE
[fuzzyclock] Fix error between 00:30 & 01:00

### DIFF
--- a/Plugins/Time/fuzzyclock.1s.py
+++ b/Plugins/Time/fuzzyclock.1s.py
@@ -50,14 +50,14 @@ def fuzzy_time(struct_time):
         return "{min} past {hr}".format(min=num_word[rounded_min],
                                         hr=num_word[hour])
     elif rounded_min == 30:
-        return "Half past {hr}".format(hr=num_word[hour])
+        return "half past {hr}".format(hr=num_word[hour])
     elif rounded_min == 45:
-        return "quarter to {hr}".format(hr=num_word[hour+1])
+        return "quarter to {hr}".format(hr=num_word[(hour + 1) % 12])
     elif rounded_min < 60 and rounded_min != 45:
         return "{min} to {hr}".format(min=num_word[60-rounded_min],
-                                      hr=num_word[hour+1])
+                                      hr=num_word[(hour + 1) % 12])
     else:
-        return "{hr} o'clock".format(hr=num_word[hour+1])
+        return "{hr} o'clock".format(hr=num_word[(hour + 1) % 12])
 
 if __name__ == '__main__':
     print(fuzzy_time(localtime()))


### PR DESCRIPTION
All time formats which added 1 to the current hour resulted in an error
between midnight and 1AM because 13 is not in the number-to-word
translation dict because the clock is 12 hour. Extra modulos have been
introduced to fix this.

Sorry that I didn't catch this first time round. Thank goodness that I stay up late.