### PR TITLE
Use monospacedDigitSystemFontOfSize on OS X 10.11+

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -75,9 +75,16 @@
   NSString * title = truncLength < titleLength ? [[fullTitle substringToIndex:truncLength] stringByAppendingString:@"…"] : fullTitle;
 
   CGFloat     size = params[@"size"] ? [params[@"size"] floatValue] : 14;
-  NSFont    * font = [self isFontValid:params[@"font"]] ? [NSFont fontWithName:params[@"font"] size:size]
-                                     : [NSFont menuFontOfSize:size]
-                                    ?: [NSFont menuFontOfSize:size];
+  NSFont    * font;
+  if ([NSFont respondsToSelector:@selector(monospacedDigitSystemFontOfSize:weight:)]) {
+    font = [self isFontValid:params[@"font"]] ? [NSFont fontWithName:params[@"font"] size:size]
+                                       : [NSFont monospacedDigitSystemFontOfSize:size weight:NSFontWeightRegular]
+                                      ?: [NSFont monospacedDigitSystemFontOfSize:size weight:NSFontWeightRegular];
+  } else {
+    font = [self isFontValid:params[@"font"]] ? [NSFont fontWithName:params[@"font"] size:size]
+                                       : [NSFont menuFontOfSize:size]
+                                       ?: [NSFont menuFontOfSize:size];
+  }
   NSColor * fgColor;
   NSMutableAttributedString * attributedTitle = [NSMutableAttributedString.alloc initWithString:title attributes:@{NSFontAttributeName: font}];
   if (!params[@"color"]) return attributedTitle;


### PR DESCRIPTION
Fixes #123 