### PR TITLE
Adding Environment variable for determining of Dark Mode is enabled

### DIFF
--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -263,6 +263,13 @@
 
     NSMutableDictionary *env = NSProcessInfo.processInfo.environment.mutableCopy;
     env[@"BitBar"] = @YES;
+      
+    // Determine if Mac is in Dark Mode
+    NSString *osxMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
+    if ([osxMode isEqualToString:@"Dark"]) {
+        env[@"BitBarDarkMode"] = @YES;
+    }
+      
     env;
   });
   


### PR DESCRIPTION
I think plugins should be able to easily tell if Dark Mode is enabled to adjust text color and other factors. I added an environment variable for this that is sent to plugins (Similar to the "BitBar" environment variable) and also made a pull request for a tutorial on how to use it.