### PR TITLE
Fix 'open at login' reset at launch time

### DIFF
--- a/App/BitBar/AppDelegate.m
+++ b/App/BitBar/AppDelegate.m
@@ -45,6 +45,7 @@
   if (DEFS.isFirstTimeAppRun) {
     LaunchAtLoginController *launcher = LaunchAtLoginController.new;
     if (!launcher.launchAtLogin) [launcher setLaunchAtLogin:YES];
+    DEFS.isFirstTimeAppRun = NO;
   }
   
   // make a plugin manager

--- a/App/BitBar/NSUserDefaults+Settings.m
+++ b/App/BitBar/NSUserDefaults+Settings.m
@@ -21,7 +21,7 @@
 - (BOOL) isFirstTimeAppRun { return ![self boolForKey:@"appHasRun"]; }
 
 - (void) setIsFirstTimeAppRun:(BOOL)firstTime {
-  [self setBool:firstTime forKey:@"appHasRun"];
+  [self setBool:!firstTime forKey:@"appHasRun"];
 }
 
 @end


### PR DESCRIPTION
Fixed a bug that 'Open at login' will be reset each time the app is launched.