### PR TITLE
Stop locking up the Menu Bar elements when NSTask is launched

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -143,6 +143,20 @@
   [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:menuItem.representedObject[@"href"]]];
 }
 
+- (void) startTask:(NSMutableDictionary*)params {
+    id task = [params[@"root"] isEqualToString:@"true"] ? STPrivilegedTask.new : NSTask.new;
+    
+    [(NSTask*)task setLaunchPath:params[@"bash"]];
+    [(NSTask*)task setArguments:params[@"args"]];
+    
+    ((NSTask*)task).terminationHandler = ^(NSTask *task) {
+      if (params[@"refresh"]) {
+        [self performSelectorOnMainThread:@selector(performRefreshNow:) withObject:NULL waitUntilDone:false];
+      }
+    };
+    [(NSTask*)task launch];
+    [(NSTask*)task waitUntilExit];
+}
 
 - (void) performMenuItemOpenTerminalAction:(NSMenuItem *)menuItem {
 
@@ -166,24 +180,10 @@
     });
     
     if([terminal isEqual: @"false"]){
-
       NSLog(@"Args: %@", args);
-
-      id task = [params[@"root"] isEqualToString:@"true"] ? STPrivilegedTask.new : NSTask.new;
-
-      [(NSTask*)task setLaunchPath:bash];
-      [(NSTask*)task setArguments:args];
-
-      if (params[@"refresh"]) {
-          ((NSTask*)task).terminationHandler = ^(NSTask *task) {
-              [self performRefreshNow:NULL];
-          };
-          [(NSTask*)task launch];
-          [(NSTask*)task waitUntilExit];
-      }
-      else {
-        [(NSTask*)task launch];
-      }
+      [params setObject:bash forKey:@"bash"];
+      [params setObject:args forKey:@"args"];
+      [self performSelectorInBackground:@selector(startTask:) withObject:params];
     } else {
 
       NSString *full_link = [NSString stringWithFormat:@"%@ %@ %@ %@ %@ %@", bash, param1, param2, param3, param4, param5];


### PR DESCRIPTION
Noticed that for long running tasks they don't really "Run in the background".  They cause the Menubar items to stop responding to clicks (normally with a spinny beach ball.)

This launches NSTask in a background thread, then does a refresh on the main thread if appropriate.

Would be great if there was a way to indicate that a background task was running, but I'm not sure how to do that.