### PR TITLE
Reset plugins on wake from sleep

### DIFF
--- a/App/BitBar/AppDelegate.m
+++ b/App/BitBar/AppDelegate.m
@@ -41,6 +41,9 @@
 
   // enable usage of Safari's WebInspector to debug HTML Plugins
   [NSUserDefaults.standardUserDefaults setBool:YES forKey:@"WebKitDeveloperExtras"];
+  [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver: self
+                                                         selector: @selector(receiveWakeNote:)
+                                                             name: NSWorkspaceDidWakeNotification object: NULL];
 
   if (DEFS.isFirstTimeAppRun) {
     LaunchAtLoginController *launcher = LaunchAtLoginController.new;
@@ -51,6 +54,11 @@
   // make a plugin manager
   [_pluginManager = [PluginManager.alloc initWithPluginPath:DEFS.pluginsDirectory]
                                                                   setupAllPlugins];
+}
+
+- (void) receiveWakeNote: (NSNotification*) note
+{
+  [[self pluginManager] reset];
 }
 
 @end


### PR DESCRIPTION
Not as elegant, but it makes sure everthing is current.  Other option would be to have each plugin track their "last run" and then compare that to their interval on wake.  If it's over, then refresh.  I went for simple over elegant ;-)

Fixes #154