### PR TITLE
Catch exceptions when NSTask fails

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -160,7 +160,11 @@
         [self performSelectorOnMainThread:@selector(performRefreshNow:) withObject:NULL waitUntilDone:false];
       }
     };
-    [(NSTask*)task launch];
+    @try {
+      [(NSTask*)task launch];
+    } @catch (NSException *e) {
+      NSLog(@"Error launching command for %@:\n\tCMD: %@\n\tARGS: %@\n%@", self.name, params[@"bash"], params[@"args"], e);
+    }
     [(NSTask*)task waitUntilExit];
 }
 


### PR DESCRIPTION
Crash reported in #165.  This fixes that crash and logs the exception as it was done before.