### PR TITLE
fixed static analyzer errors

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -16,9 +16,9 @@
 
 @implementation Plugin
 
-- init { return self = super.init ? _currentLine = -1, _cycleLinesIntervalSeconds = 5, self : nil; }
+- init { return (self = super.init) ? _currentLine = -1, _cycleLinesIntervalSeconds = 5, self : nil; }
 
-- initWithManager:(PluginManager*)manager { return self = self.init ? _manager = manager, self : nil; }
+- initWithManager:(PluginManager*)manager { return (self = self.init) ? _manager = manager, self : nil; }
 
 - (NSStatusItem *)statusItem { return _statusItem = _statusItem ?: ({
     

--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -17,7 +17,7 @@
 
 - initWithPluginPath:(NSString*)path {
 
-  return self = super.init ? _path = path.stringByStandardizingPath, self : nil;
+  return (self = super.init) ? _path = path.stringByStandardizingPath, self : nil;
 }
 
 - (void) showSystemStatusItemWithMessage:(NSString*)message {


### PR DESCRIPTION
Before (Product > Analyze):

![screenshot](https://cloud.githubusercontent.com/assets/655921/13059956/2b120a38-d42e-11e5-98a9-fb1760e6b2a5.png)

Now there is just one error in the `LaunchAtLoginController` dependency.