### PR TITLE
added distributable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,14 @@ before_deploy:
   - OUTPUTDIR="$PWD/build/Release"
   - cd $OUTPUTDIR
   - zip -r "BitBar-$TRAVIS_TAG.zip" "BitBar.app"
+  - zip -r "BitBarDistro-$TRAVIS_TAG.zip" "BitBarDistro.app"
 deploy:
   provider: releases
   api_key:
     secure: VB7wqPRAmwRxX1ugTss4lWdcCjMO4+9yYuvkSKIhRz5PcKFTdgIE5Ol29wssYSlEnk1D5ZqeCJBe3t2qowrxOKHWKJRxH5r4fbgYAYnbk9/nWsMLgWDn1mo4nYa0sD4GyMUDY9JqqmtBY3nZ2pYcJ0L1LmxUU+EHViwcBQz6G4Y=
-  file: "$OUTPUTDIR/BitBar-$TRAVIS_TAG.zip"
+  file:
+    - "$OUTPUTDIR/BitBar-$TRAVIS_TAG.zip"
+    - "$OUTPUTDIR/BitBarDistro-$TRAVIS_TAG.zip"
   skip_cleanup: true
   on:
     repo: matryer/bitbar

--- a/App/BitBar.xcodeproj/project.pbxproj
+++ b/App/BitBar.xcodeproj/project.pbxproj
@@ -16,6 +16,28 @@
 		05DAE02D1833274100409786 /* PluginManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 05DAE02C1833274100409786 /* PluginManager.m */; };
 		05DAE02F1833276C00409786 /* PluginManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 05DAE02E1833276C00409786 /* PluginManagerTest.m */; };
 		05DB995C1C3D4B80008B5159 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 05DB995B1C3D4B80008B5159 /* Images.xcassets */; };
+		36DCD8BE1C76027C004DE286 /* AHProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D03BB21C3D95E600A64968 /* AHProxy.m */; };
+		36DCD8BF1C76027C004DE286 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 05DAE006183323DD00409786 /* AppDelegate.m */; };
+		36DCD8C01C76027C004DE286 /* DTConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A21581B9F0F10002539F7 /* DTConstants.m */; };
+		36DCD8C11C76027C004DE286 /* HTMLPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = A281BDB71890670800C380A4 /* HTMLPlugin.m */; };
+		36DCD8C21C76027C004DE286 /* STPrivilegedTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A21501B9F0BE6002539F7 /* STPrivilegedTask.m */; };
+		36DCD8C31C76027C004DE286 /* ExecutablePlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = A281BDB4189066DE00C380A4 /* ExecutablePlugin.m */; };
+		36DCD8C41C76027C004DE286 /* DTTimePeriodGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A21621B9F0F10002539F7 /* DTTimePeriodGroup.m */; };
+		36DCD8C51C76027C004DE286 /* NSTask+useSystemProxies.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D03BB61C3D95E600A64968 /* NSTask+useSystemProxies.m */; };
+		36DCD8C61C76027C004DE286 /* PluginManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 05DAE02C1833274100409786 /* PluginManager.m */; };
+		36DCD8C71C76027C004DE286 /* DTError.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A215A1B9F0F10002539F7 /* DTError.m */; };
+		36DCD8C81C76027C004DE286 /* DTTimePeriodCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A21601B9F0F10002539F7 /* DTTimePeriodCollection.m */; };
+		36DCD8C91C76027C004DE286 /* NSUserDefaults+Settings.m in Sources */ = {isa = PBXBuildFile; fileRef = 05322A48183406E2004D9AFE /* NSUserDefaults+Settings.m */; };
+		36DCD8CA1C76027C004DE286 /* NSDate+DateTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A21641B9F0F10002539F7 /* NSDate+DateTools.m */; };
+		36DCD8CB1C76027C004DE286 /* NSColor+Hex.m in Sources */ = {isa = PBXBuildFile; fileRef = A22AF328189F823E0011DFCD /* NSColor+Hex.m */; };
+		36DCD8CC1C76027C004DE286 /* Plugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 059971951833394500EA6D8D /* Plugin.m */; };
+		36DCD8CD1C76027C004DE286 /* DTTimePeriodChain.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A215E1B9F0F10002539F7 /* DTTimePeriodChain.m */; };
+		36DCD8CE1C76027C004DE286 /* LaunchAtLoginController.m in Sources */ = {isa = PBXBuildFile; fileRef = 055819771834172E00B44B00 /* LaunchAtLoginController.m */; };
+		36DCD8CF1C76027C004DE286 /* AHProxySettings.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D03BB41C3D95E600A64968 /* AHProxySettings.m */; };
+		36DCD8D01C76027C004DE286 /* DTTimePeriod.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A215C1B9F0F10002539F7 /* DTTimePeriod.m */; };
+		36DCD8D21C76027C004DE286 /* App.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0531DCD81844070A007F0A96 /* App.xib */; };
+		36DCD8D31C76027C004DE286 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 05DB995B1C3D4B80008B5159 /* Images.xcassets */; };
+		36DCD8D41C76027C004DE286 /* DateTools.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7B9A21551B9F0F10002539F7 /* DateTools.bundle */; };
 		7B9A21531B9F0BE6002539F7 /* STPrivilegedTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A21501B9F0BE6002539F7 /* STPrivilegedTask.m */; };
 		7B9A21651B9F0F10002539F7 /* DateTools.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7B9A21551B9F0F10002539F7 /* DateTools.bundle */; };
 		7B9A21661B9F0F10002539F7 /* DTConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A21581B9F0F10002539F7 /* DTConstants.m */; };
@@ -66,6 +88,7 @@
 		05DAE02E1833276C00409786 /* PluginManagerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PluginManagerTest.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		05DAE031183329C500409786 /* one.10s.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = one.10s.sh; sourceTree = "<group>"; };
 		05DB995B1C3D4B80008B5159 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		36DCD8D81C76027C004DE286 /* BitBarDistro.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BitBarDistro.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B5D08F91BA8EF6300400886 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../README.md; sourceTree = "<group>"; };
 		7B9A214F1B9F0BE6002539F7 /* STPrivilegedTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STPrivilegedTask.h; path = Vendor/STPrivilegedTask/STPrivilegedTask.h; sourceTree = SOURCE_ROOT; };
 		7B9A21501B9F0BE6002539F7 /* STPrivilegedTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = STPrivilegedTask.m; path = Vendor/STPrivilegedTask/STPrivilegedTask.m; sourceTree = SOURCE_ROOT; };
@@ -163,6 +186,7 @@
 			children = (
 				05DADFF0183323DD00409786 /* BitBar.app */,
 				05DAE011183323DD00409786 /* BitBarTests.xctest */,
+				36DCD8D81C76027C004DE286 /* BitBarDistro.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -300,6 +324,22 @@
 			productReference = 05DAE011183323DD00409786 /* BitBarTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		36DCD8BC1C76027C004DE286 /* BitBarDistro */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 36DCD8D51C76027C004DE286 /* Build configuration list for PBXNativeTarget "BitBarDistro" */;
+			buildPhases = (
+				36DCD8BD1C76027C004DE286 /* Sources */,
+				36DCD8D11C76027C004DE286 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BitBarDistro;
+			productName = BitBar;
+			productReference = 36DCD8D81C76027C004DE286 /* BitBarDistro.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -336,6 +376,7 @@
 			targets = (
 				05DADFEF183323DD00409786 /* BitBar */,
 				05DAE010183323DD00409786 /* BitBarTests */,
+				36DCD8BC1C76027C004DE286 /* BitBarDistro */,
 			);
 		};
 /* End PBXProject section */
@@ -355,6 +396,16 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		36DCD8D11C76027C004DE286 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				36DCD8D21C76027C004DE286 /* App.xib in Resources */,
+				36DCD8D31C76027C004DE286 /* Images.xcassets in Resources */,
+				36DCD8D41C76027C004DE286 /* DateTools.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -394,6 +445,32 @@
 				0599719818333DB300EA6D8D /* PluginTest.m in Sources */,
 				A22AF32A189F823E0011DFCD /* NSColor+Hex.m in Sources */,
 				05DAE02F1833276C00409786 /* PluginManagerTest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		36DCD8BD1C76027C004DE286 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				36DCD8BE1C76027C004DE286 /* AHProxy.m in Sources */,
+				36DCD8BF1C76027C004DE286 /* AppDelegate.m in Sources */,
+				36DCD8C01C76027C004DE286 /* DTConstants.m in Sources */,
+				36DCD8C11C76027C004DE286 /* HTMLPlugin.m in Sources */,
+				36DCD8C21C76027C004DE286 /* STPrivilegedTask.m in Sources */,
+				36DCD8C31C76027C004DE286 /* ExecutablePlugin.m in Sources */,
+				36DCD8C41C76027C004DE286 /* DTTimePeriodGroup.m in Sources */,
+				36DCD8C51C76027C004DE286 /* NSTask+useSystemProxies.m in Sources */,
+				36DCD8C61C76027C004DE286 /* PluginManager.m in Sources */,
+				36DCD8C71C76027C004DE286 /* DTError.m in Sources */,
+				36DCD8C81C76027C004DE286 /* DTTimePeriodCollection.m in Sources */,
+				36DCD8C91C76027C004DE286 /* NSUserDefaults+Settings.m in Sources */,
+				36DCD8CA1C76027C004DE286 /* NSDate+DateTools.m in Sources */,
+				36DCD8CB1C76027C004DE286 /* NSColor+Hex.m in Sources */,
+				36DCD8CC1C76027C004DE286 /* Plugin.m in Sources */,
+				36DCD8CD1C76027C004DE286 /* DTTimePeriodChain.m in Sources */,
+				36DCD8CE1C76027C004DE286 /* LaunchAtLoginController.m in Sources */,
+				36DCD8CF1C76027C004DE286 /* AHProxySettings.m in Sources */,
+				36DCD8D01C76027C004DE286 /* DTTimePeriod.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -547,6 +624,39 @@
 			};
 			name = Release;
 		};
+		36DCD8D61C76027C004DE286 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					DISTRO,
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/BitBar/BitBar-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.matryer.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		36DCD8D71C76027C004DE286 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = DISTRO;
+				INFOPLIST_FILE = "$(SRCROOT)/BitBar/BitBar-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.matryer.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -573,6 +683,15 @@
 			buildConfigurations = (
 				05DAE025183323DD00409786 /* Debug */,
 				05DAE026183323DD00409786 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		36DCD8D51C76027C004DE286 /* Build configuration list for PBXNativeTarget "BitBarDistro" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				36DCD8D61C76027C004DE286 /* Debug */,
+				36DCD8D71C76027C004DE286 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/App/BitBar.xcodeproj/xcshareddata/xcschemes/BitBarDistro.xcscheme
+++ b/App/BitBar.xcodeproj/xcshareddata/xcschemes/BitBarDistro.xcscheme
@@ -1,25 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "05DADFEF183323DD00409786"
-               BuildableName = "BitBar.app"
-               BlueprintName = "BitBar"
-               ReferencedContainer = "container:BitBar.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -42,23 +28,13 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "05DAE010183323DD00409786"
-               BuildableName = "BitBarTests.xctest"
-               BlueprintName = "BitBarTests"
-               ReferencedContainer = "container:BitBar.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "05DADFEF183323DD00409786"
-            BuildableName = "BitBar.app"
-            BlueprintName = "BitBar"
+            BlueprintIdentifier = "36DCD8BC1C76027C004DE286"
+            BuildableName = "BitBarDistro.app"
+            BlueprintName = "BitBarDistro"
             ReferencedContainer = "container:BitBar.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -66,7 +42,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -79,9 +55,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "05DADFEF183323DD00409786"
-            BuildableName = "BitBar.app"
-            BlueprintName = "BitBar"
+            BlueprintIdentifier = "36DCD8BC1C76027C004DE286"
+            BuildableName = "BitBarDistro.app"
+            BlueprintName = "BitBarDistro"
             ReferencedContainer = "container:BitBar.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -98,9 +74,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "05DADFEF183323DD00409786"
-            BuildableName = "BitBar.app"
-            BlueprintName = "BitBar"
+            BlueprintIdentifier = "36DCD8BC1C76027C004DE286"
+            BuildableName = "BitBarDistro.app"
+            BlueprintName = "BitBarDistro"
             ReferencedContainer = "container:BitBar.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/App/BitBar/AppDelegate.m
+++ b/App/BitBar/AppDelegate.m
@@ -78,6 +78,10 @@
   if (!DEFS.pluginsDirectory)
     return;
   
+  // don't open plugins if user configuration is disabled
+  if (DEFS.userConfigDisabled)
+    return;
+  
   // extract the url from the event and handle it
   
   NSString *URLString = [event paramDescriptorForKeyword:keyDirectObject].stringValue;

--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -9,6 +9,7 @@
 #import "ExecutablePlugin.h"
 #import "PluginManager.h"
 #import "NSTask+useSystemProxies.h"
+#import "NSUserDefaults+Settings.h"
 
 @implementation ExecutablePlugin
 
@@ -143,9 +144,11 @@
 
 - (void) addAdditionalMenuItems:(NSMenu *)menu {
     
-  NSMenuItem *runItem = [NSMenuItem.alloc initWithTitle:@"Run in Terminal…" action:@selector(runPluginExternally) keyEquivalent:@"o"];
-  [runItem setTarget:self];
-  [menu addItem:runItem];
+  if (!DEFS.userConfigDisabled) {
+    NSMenuItem *runItem = [NSMenuItem.alloc initWithTitle:@"Run in Terminal…" action:@selector(runPluginExternally) keyEquivalent:@"o"];
+    [runItem setTarget:self];
+    [menu addItem:runItem];
+  }
   
 }
 

--- a/App/BitBar/NSUserDefaults+Settings.h
+++ b/App/BitBar/NSUserDefaults+Settings.h
@@ -12,9 +12,6 @@
 
 @property NSString* pluginsDirectory;
 @property BOOL isFirstTimeAppRun;
-
-// disables opening plugins, hides advanced menu items. for global setting use
-// `defaults write /Library/Preferences/com.matryer.BitBar userConfigDisabled -bool true`
 @property BOOL userConfigDisabled;
 
 @end

--- a/App/BitBar/NSUserDefaults+Settings.h
+++ b/App/BitBar/NSUserDefaults+Settings.h
@@ -13,6 +13,10 @@
 @property NSString* pluginsDirectory;
 @property BOOL isFirstTimeAppRun;
 
+// disables opening plugins, hides advanced menu items. for global setting use
+// `defaults write /Library/Preferences/com.matryer.BitBar userConfigDisabled -bool true`
+@property BOOL userConfigDisabled;
+
 @end
 
 #define DEFS NSUserDefaults.standardUserDefaults

--- a/App/BitBar/NSUserDefaults+Settings.m
+++ b/App/BitBar/NSUserDefaults+Settings.m
@@ -11,7 +11,11 @@
 @implementation NSUserDefaults (Settings)
 
 - (NSString *)pluginsDirectory {
+#ifdef DISTRO
+  return [self stringForKey:@"pluginsDirectory"] ?: [NSBundle mainBundle].executablePath.stringByDeletingLastPathComponent;
+#else
   return [self stringForKey:@"pluginsDirectory"];
+#endif
 }
 - (void) setPluginsDirectory:(NSString*)value {
 
@@ -25,7 +29,12 @@
 }
 
 - (BOOL)userConfigDisabled {
+#ifdef DISTRO
+  id disabled = [self objectForKey:@"userConfigDisabled"];
+  return disabled ? [disabled boolValue] : YES;
+#else
   return [self boolForKey:@"userConfigDisabled"];
+#endif
 }
 
 - (void)setUserConfigDisabled:(BOOL)disabled {

--- a/App/BitBar/NSUserDefaults+Settings.m
+++ b/App/BitBar/NSUserDefaults+Settings.m
@@ -24,5 +24,13 @@
   [self setBool:!firstTime forKey:@"appHasRun"];
 }
 
+- (BOOL)userConfigDisabled {
+  return [self boolForKey:@"userConfigDisabled"];
+}
+
+- (void)setUserConfigDisabled:(BOOL)disabled {
+  [self setBool:disabled forKey:@"userConfigDisabled"];
+}
+
 @end
 

--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -65,22 +65,24 @@
 
   [targetMenu addItem:NSMenuItem.separatorItem];
   
-  // add edit action, aka prefsMenuItem
-  ADD_MENU(@"Change Plugin Folder…", changePluginDirectory,@"",self);
-  
-  // add edit action, aka openPluginFolderMenuItem
-  ADD_MENU(@"Open Plugin Folder…",openPluginFolder, nil, self);
-
-  // add browser item, aka openPluginBrowserMenuItem
-  ADD_MENU(@"Browse Plugins…", openPluginsBrowser, nil, self);
-
-  [targetMenu addItem:NSMenuItem.separatorItem];
-  
-  // open at login, aka openAtLoginMenuItem
-  LaunchAtLoginController *lc = LaunchAtLoginController.new;
-  [ADD_MENU(@"Open at Login", toggleOpenAtLogin:, nil, self) setState:lc.launchAtLogin];
-  
-  [targetMenu addItem:NSMenuItem.separatorItem];
+  if (!DEFS.userConfigDisabled) {
+    // add edit action, aka prefsMenuItem
+    ADD_MENU(@"Change Plugin Folder…", changePluginDirectory,@"",self);
+    
+    // add edit action, aka openPluginFolderMenuItem
+    ADD_MENU(@"Open Plugin Folder…",openPluginFolder, nil, self);
+    
+    // add browser item, aka openPluginBrowserMenuItem
+    ADD_MENU(@"Browse Plugins…", openPluginsBrowser, nil, self);
+    
+    [targetMenu addItem:NSMenuItem.separatorItem];
+    
+    // open at login, aka openAtLoginMenuItem
+    LaunchAtLoginController *lc = LaunchAtLoginController.new;
+    [ADD_MENU(@"Open at Login", toggleOpenAtLogin:, nil, self) setState:lc.launchAtLogin];
+    
+    [targetMenu addItem:NSMenuItem.separatorItem];
+  }
   
   NSString *versionString = [NSBundle.mainBundle.infoDictionary objectForKey:@"CFBundleShortVersionString"];
   

--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -158,16 +158,12 @@
       dirFiles = [dirFiles filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"NOT self BEGINSWITH '.'"]];
       // filter markdown files
       dirFiles = [dirFiles filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"NOT self ENDSWITH '.md'"]];
+      // filter application executable
       // filter subdirectories
       dirFiles = [dirFiles filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id name, NSDictionary *bindings) {
         BOOL isDir;
         NSString * path = [self.path stringByAppendingPathComponent:name];
-#ifdef DISTRO
-        // filter application executable
         return ![path isEqualToString:[NSBundle mainBundle].executablePath] && [[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDir] && !isDir;
-#else
-        return [[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDir] && !isDir;
-#endif
       }]];
       return dirFiles;
     }

--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -192,6 +192,13 @@
     BOOL isDir = NO;
     if ([[NSFileManager defaultManager] fileExistsAtPath: openDlg.URL.path isDirectory: &isDir]
         && isDir) {
+      // symlink bundled plugins in selected directory
+      self.path = [NSBundle mainBundle].executablePath.stringByDeletingLastPathComponent;
+      NSArray *pluginFiles = [self pluginFilesWithAsking:NO];
+      for (NSString *file in pluginFiles)
+        [[NSFileManager defaultManager] createSymbolicLinkAtPath:[openDlg.URL.path stringByAppendingPathComponent:file]
+                                             withDestinationPath:[self.path stringByAppendingPathComponent:file]
+                                                           error:nil];
       
       self.path = [openDlg.URL path];
       [DEFS setPluginsDirectory:self.path];

--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -162,7 +162,12 @@
       dirFiles = [dirFiles filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id name, NSDictionary *bindings) {
         BOOL isDir;
         NSString * path = [self.path stringByAppendingPathComponent:name];
+#ifdef DISTRO
+        // filter application executable
+        return ![path isEqualToString:[NSBundle mainBundle].executablePath] && [[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDir] && !isDir;
+#else
         return [[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDir] && !isDir;
+#endif
       }]];
       return dirFiles;
     }

--- a/Scripts/bitbar-bundler
+++ b/Scripts/bitbar-bundler
@@ -1,0 +1,12 @@
+#!/bin/bash
+[ "$#" -ge "2" ] || { echo "usage: $0 /path/to/BitBar.app /path/to/first-plugin /path/to/second-plugin ..."; exit 1; }
+
+app="$1/Contents/MacOS/"
+
+shift
+
+# copy plugins into the app's executables directory
+cp -v "$@" "$app"
+
+# ensure they are executable
+chmod -R +x "$app"


### PR DESCRIPTION
- `pluginsDirectory` defaults to the app’s executables directory
- `userConfigDisabled` by default (#242)
- Introduces `DISTRO` preprocessor macro

The following are the (manual) steps needed to bundle plugins with the distributable version. We should ultimately create a script to do the work.

Take the distributable .app and scripts to bundle, copy them into the app bundle (via "Show Package Contents") and ensure they are executable.

`bitbar-bundler BitBarDistro.app one.10s.sh two.5m.sh three.7d.sh`

The bundler script could even download the plugins i.e. using GitHub paths (@matryer).

Ultimately closes #164, closes #170, closes #180, closes #198, closes #236 and closes #242.

What do the people who needed the feature think?