### PR TITLE
Point LaunchAtLoginController submodule to a new remote to fix a memory leak

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/MatthewYork/DateTools.git
 [submodule "App/Vendor/LaunchAtLoginController"]
 	path = App/Vendor/LaunchAtLoginController
-	url = https://github.com/mralexgray/LaunchAtLoginController--with-ARC-.git
+	url = https://github.com/ksuther/LaunchAtLoginController--with-ARC-.git
 [submodule "App/Vendor/AHProxySettings"]
 	path = App/Vendor/AHProxySettings
 	url = https://github.com/eahrold/AHProxySettings.git


### PR DESCRIPTION
Fixes #235. Be sure to run `git submodule sync` to update to the new remote.