### PR TITLE
Remove updatePluginLastUpdatedValues and the update timer

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -503,6 +503,8 @@
   self.statusItem.attributedTitle = [self attributedTitleWithParams:params];
   
   [self.statusItem setHighlightMode:YES];
+
+  [self.lastUpdatedMenuItem setTitle:self.lastUpdated ? [NSString stringWithFormat:@"Updated %@", self.lastUpdatedString] : @"Refreshing…"];
 }
 
 - (void)menuDidClose:(NSMenu *)menu {

--- a/App/BitBar/PluginManager.h
+++ b/App/BitBar/PluginManager.h
@@ -15,7 +15,6 @@
 @property (nonatomic)        NSArray *plugins;
 @property (nonatomic)    NSStatusBar *statusBar;
 @property (nonatomic)   NSStatusItem *defaultStatusItem;
-@property (nonatomic)        NSTimer *timerForLastUpdated;
 @property (nonatomic)   NSDictionary *environment;
 
 - initWithPluginPath:(NSString *)path;

--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -316,17 +316,7 @@
     
     for (Plugin *plugin in plugins) [plugin refresh];
 
-    [_timerForLastUpdated invalidate];
-    self.timerForLastUpdated = [NSTimer scheduledTimerWithTimeInterval:5 target:self selector:@selector(updatePluginLastUpdatedValues) userInfo:nil repeats:YES];
-    
   }
-}
-
-- (void)updatePluginLastUpdatedValues {
-
-  for (Plugin *plugin in self.plugins)
-    plugin.lastUpdated  ? [plugin.lastUpdatedMenuItem setTitle:[NSString stringWithFormat:@"Updated %@", plugin.lastUpdatedString]]
-                        : [plugin.lastUpdatedMenuItem setTitle:@"Refreshing…"];
 }
 
 #pragma mark - NSMenuDelegate


### PR DESCRIPTION
Use menuWillOpen to update the last update menu item. Eliminates a timer that is running all the time in the background.