### PR TITLE
Add templateImage parameter

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -30,7 +30,7 @@
   
 }
 
-- (NSImage*) createImageFromBase64:(NSString*)string {
+- (NSImage*) createImageFromBase64:(NSString*)string isTemplate:(BOOL)template{
   NSData * imageData;
   if ([NSData instancesRespondToSelector:@selector(initWithBase64EncodedString:options:)]) {
     imageData = [[NSData alloc] initWithBase64EncodedString:string options:0];
@@ -38,6 +38,9 @@
     imageData = [[NSData alloc] initWithBase64Encoding:string];
   }
   NSImage * image = [[NSImage alloc] initWithData:imageData];
+  if (template) {
+    [image setTemplate:true];
+  }
   return image;
 }
 
@@ -79,8 +82,10 @@
     item.alternate = YES;
     item.keyEquivalentModifierMask = NSAlternateKeyMask;
   }
-  if (params[@"image"]) {
-    item.image = [self createImageFromBase64:params[@"image"]];
+  if (params[@"templateImage"]) {
+    item.image = [self createImageFromBase64:params[@"templateImage"] isTemplate:true];
+  }else if (params[@"image"]) {
+    item.image = [self createImageFromBase64:params[@"image"] isTemplate:false];
   }
 
   return item;
@@ -362,9 +367,12 @@
     }
     
     // Add image if present
-    if (params[@"image"]) {
-      self.statusItem.image = [self createImageFromBase64:params[@"image"]];
+    if (params[@"templateImage"]) {
+      self.statusItem.image = [self createImageFromBase64:params[@"templateImage"] isTemplate:true];
+    }else if (params[@"image"]) {
+      self.statusItem.image = [self createImageFromBase64:params[@"image"] isTemplate:false];
     }
+    
     
     self.statusItem.attributedTitle = [self attributedTitleWithParams:params];
     self.pluginIsVisible = YES;

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If you want to contribute, please send us a pull request and we'll add it to our
     * `length=..` to truncate the line to the specified number of characters. A `…` will be added to any truncated strings, as well as a tooltip displaying the full string. eg. `length=10`
     * `trim=..` whether to trim leading/trailing whitespace from the title.  `true` or `false` (defaults to `true`)
     * `alternate=true` to mark a line as an alternate to the previous one for when the Option key is pressed in the dropdown
-    * `templateImage=..` set an image for this item. The image data must be passed as base64 encoded string and should consist of only black and clear colors. The alpha channel in the image can be used to adjust the opacity of black content, however. This is the recommended way to set an image for the statusbar. The imageformat can be any of the formats supported by Mac OS X
+    * `templateImage=..` set an image for this item. The image data must be passed as base64 encoded string and should consist of only black and clear pixels. The alpha channel in the image can be used to adjust the opacity of black content, however. This is the recommended way to set an image for the statusbar. The imageformat can be any of the formats supported by Mac OS X
     * `image=..` set an image for this item. The image data must be passed as base64 encoded string. The imageformat can be any of the formats supported by Mac OS X
 
 ### Metadata

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ If you want to contribute, please send us a pull request and we'll add it to our
     * `length=..` to truncate the line to the specified number of characters. A `…` will be added to any truncated strings, as well as a tooltip displaying the full string. eg. `length=10`
     * `trim=..` whether to trim leading/trailing whitespace from the title.  `true` or `false` (defaults to `true`)
     * `alternate=true` to mark a line as an alternate to the previous one for when the Option key is pressed in the dropdown
+    * `templateImage=..` set an image for this item. The image data must be passed as base64 encoded string and should consist of only black and clear colors. The alpha channel in the image can be used to adjust the opacity of black content, however. This is the recommended way to set an image for the statusbar. The imageformat can be any of the formats supported by Mac OS X
     * `image=..` set an image for this item. The image data must be passed as base64 encoded string. The imageformat can be any of the formats supported by Mac OS X
 
 ### Metadata


### PR DESCRIPTION
Added a templateImage parameter as discussed in Slack.
This allows Mac OS X to change the styling in the StatusBar to fit the different themes better.