### PR TITLE
Escaped spaces in the path when opening in terminal

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -238,11 +238,12 @@
       [self performSelectorInBackground:@selector(startTask:) withObject:params];
     } else {
 
-      NSString *full_link = [NSString stringWithFormat:@"%@ %@ %@ %@ %@ %@", bash, param1, param2, param3, param4, param5];
+      NSString *full_link = [NSString stringWithFormat:@"%@ %@ %@ %@ %@", param1, param2, param3, param4, param5];
       NSString *s = [NSString stringWithFormat:@"tell application \"Terminal\" \n\
-                 do script \"%@\" \n\
+                 set scriptPath to \"%@\"\n\
+                 do script quoted form of scriptPath & \" %@\" \n\
                  activate \n\
-                 end tell", full_link];
+                 end tell", bash, full_link];
       NSAppleScript *as = [NSAppleScript.alloc initWithSource: s];
       [as executeAndReturnError:nil];
     }

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ For a real example, see the [Cycle text and detail plugin source code](https://g
   * You can add to `PATH` by including something like `export PATH='/usr/local/bin:/usr/bin:$PATH'` in your plugin script.
   * You can use emoji in the output (find an example in the Music/vox Plugin).
   * If your bash script generates text in another language, set the `LANG` variable with: `export LANG="es_ES.UTF-8"` (for Spanish) to show the text in correct format.
+  * If you want to call the plugin script for action, you can use `bash=$0`
 
 ### Examples
 


### PR DESCRIPTION
- New method [Plugin resolveScriptPath:] that resolves paths
- [ExecutablePlugin resolveScriptPath:] handled special `@self` reference and replaces with `self.path`
- Changed AppleScript execution to handle spaces