### PR TITLE
Implemented simple ANSI color code support. Use parameter `ansi=false` to disable

### DIFF
--- a/App/BitBar.xcodeproj/project.pbxproj
+++ b/App/BitBar.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		AE3C16791C93F716009AF7CA /* NSString+Emojize.m in Sources */ = {isa = PBXBuildFile; fileRef = AE7303D81C935BDE00AF5499 /* NSString+Emojize.m */; };
 		AE3C167A1C93F71B009AF7CA /* NSString+Emojize.m in Sources */ = {isa = PBXBuildFile; fileRef = AE7303D81C935BDE00AF5499 /* NSString+Emojize.m */; };
 		AE7303DB1C935BDE00AF5499 /* NSString+Emojize.m in Sources */ = {isa = PBXBuildFile; fileRef = AE7303D81C935BDE00AF5499 /* NSString+Emojize.m */; };
+		AE3C16781C93F1F9009AF7CA /* NSString+ANSI.m in Sources */ = {isa = PBXBuildFile; fileRef = AE7303EC1C93984C00AF5499 /* NSString+ANSI.m */; };
 		AE7303DD1C93721600AF5499 /* TestPlugins in Resources */ = {isa = PBXBuildFile; fileRef = AE7303DC1C93721600AF5499 /* TestPlugins */; };
 		AE7303E01C93848400AF5499 /* PluginManager+Test.m in Sources */ = {isa = PBXBuildFile; fileRef = AE7303DF1C93848400AF5499 /* PluginManager+Test.m */; };
 		AE7303E11C9386CE00AF5499 /* PluginManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 05DAE02C1833274100409786 /* PluginManager.m */; };
@@ -540,6 +541,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE3C16791C93F716009AF7CA /* NSString+Emojize.m in Sources */,
+				AE3C16781C93F1F9009AF7CA /* NSString+ANSI.m in Sources */,
 				AE7303EA1C9387F300AF5499 /* NSUserDefaults+Settings.m in Sources */,
 				AE7303E51C93871200AF5499 /* AHProxy.m in Sources */,
 				AE7303E61C93871200AF5499 /* AHProxySettings.m in Sources */,

--- a/App/BitBar.xcodeproj/project.pbxproj
+++ b/App/BitBar.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		AE7303EA1C9387F300AF5499 /* NSUserDefaults+Settings.m in Sources */ = {isa = PBXBuildFile; fileRef = 05322A48183406E2004D9AFE /* NSUserDefaults+Settings.m */; };
 		AE8833781C95433B00D5A191 /* NSString+Emojize.m in Sources */ = {isa = PBXBuildFile; fileRef = AE7303D81C935BDE00AF5499 /* NSString+Emojize.m */; };
 		AE7303ED1C93984C00AF5499 /* NSString+ANSI.m in Sources */ = {isa = PBXBuildFile; fileRef = AE7303EC1C93984C00AF5499 /* NSString+ANSI.m */; };
+		AE8833791C9544F200D5A191 /* NSString+ANSI.m in Sources */ = {isa = PBXBuildFile; fileRef = AE7303EC1C93984C00AF5499 /* NSString+ANSI.m */; };
 		F8D03BB71C3D95E600A64968 /* AHProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D03BB21C3D95E600A64968 /* AHProxy.m */; };
 		F8D03BB81C3D95E600A64968 /* AHProxySettings.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D03BB41C3D95E600A64968 /* AHProxySettings.m */; };
 		F8D03BB91C3D95E600A64968 /* NSTask+useSystemProxies.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D03BB61C3D95E600A64968 /* NSTask+useSystemProxies.m */; };
@@ -564,6 +565,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE8833781C95433B00D5A191 /* NSString+Emojize.m in Sources */,
+				AE8833791C9544F200D5A191 /* NSString+ANSI.m in Sources */,
 				36372DC21C9424DB0005EB32 /* NSUserDefaults+Settings.m in Sources */,
 				36372DC31C9424DB0005EB32 /* AHProxy.m in Sources */,
 				36372DC41C9424DB0005EB32 /* AHProxySettings.m in Sources */,

--- a/App/BitBar.xcodeproj/project.pbxproj
+++ b/App/BitBar.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		AE7303E91C93871200AF5499 /* LaunchAtLoginController.m in Sources */ = {isa = PBXBuildFile; fileRef = 055819771834172E00B44B00 /* LaunchAtLoginController.m */; };
 		AE7303EA1C9387F300AF5499 /* NSUserDefaults+Settings.m in Sources */ = {isa = PBXBuildFile; fileRef = 05322A48183406E2004D9AFE /* NSUserDefaults+Settings.m */; };
 		AE8833781C95433B00D5A191 /* NSString+Emojize.m in Sources */ = {isa = PBXBuildFile; fileRef = AE7303D81C935BDE00AF5499 /* NSString+Emojize.m */; };
+		AE7303ED1C93984C00AF5499 /* NSString+ANSI.m in Sources */ = {isa = PBXBuildFile; fileRef = AE7303EC1C93984C00AF5499 /* NSString+ANSI.m */; };
 		F8D03BB71C3D95E600A64968 /* AHProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D03BB21C3D95E600A64968 /* AHProxy.m */; };
 		F8D03BB81C3D95E600A64968 /* AHProxySettings.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D03BB41C3D95E600A64968 /* AHProxySettings.m */; };
 		F8D03BB91C3D95E600A64968 /* NSTask+useSystemProxies.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D03BB61C3D95E600A64968 /* NSTask+useSystemProxies.m */; };
@@ -156,6 +157,8 @@
 		AE7303DC1C93721600AF5499 /* TestPlugins */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TestPlugins; sourceTree = "<group>"; };
 		AE7303DE1C93848400AF5499 /* PluginManager+Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PluginManager+Test.h"; sourceTree = "<group>"; };
 		AE7303DF1C93848400AF5499 /* PluginManager+Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PluginManager+Test.m"; sourceTree = "<group>"; };
+		AE7303EB1C93984C00AF5499 /* NSString+ANSI.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = "NSString+ANSI.h"; sourceTree = "<group>"; tabWidth = 2; };
+		AE7303EC1C93984C00AF5499 /* NSString+ANSI.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = "NSString+ANSI.m"; sourceTree = "<group>"; tabWidth = 2; };
 		F8D03BB11C3D95E600A64968 /* AHProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AHProxy.h; sourceTree = "<group>"; };
 		F8D03BB21C3D95E600A64968 /* AHProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AHProxy.m; sourceTree = "<group>"; };
 		F8D03BB31C3D95E600A64968 /* AHProxySettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AHProxySettings.h; sourceTree = "<group>"; };
@@ -224,6 +227,7 @@
 				05DAE006183323DD00409786 /* AppDelegate.m */,
 				05DAE0271833241D00409786 /* Plugins */,
 				05322A46183406D7004D9AFE /* Settings */,
+				AE3C16771C93B135009AF7CA /* Extensions */,
 				055EB10C183472C400FF83A6 /* Vendor */,
 				05DADFFA183323DD00409786 /* Supporting Files */,
 				05DAE017183323DD00409786 /* BitBarTests */,
@@ -328,6 +332,16 @@
 			name = NSStringEmojize;
 			path = Vendor/NSStringEmojize/NSStringEmojize;
 			sourceTree = SOURCE_ROOT;
+		};
+		AE3C16771C93B135009AF7CA /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				AE7303EB1C93984C00AF5499 /* NSString+ANSI.h */,
+				AE7303EC1C93984C00AF5499 /* NSString+ANSI.m */,
+			);
+			name = Extensions;
+			path = BitBar;
+			sourceTree = "<group>";
 		};
 		F8D03BB01C3D95E600A64968 /* AHProxySettings */ = {
 			isa = PBXGroup;
@@ -514,6 +528,7 @@
 				A22AF329189F823E0011DFCD /* NSColor+Hex.m in Sources */,
 				059971961833394500EA6D8D /* Plugin.m in Sources */,
 				7B9A21691B9F0F10002539F7 /* DTTimePeriodChain.m in Sources */,
+				AE7303ED1C93984C00AF5499 /* NSString+ANSI.m in Sources */,
 				055819781834172E00B44B00 /* LaunchAtLoginController.m in Sources */,
 				F8D03BB81C3D95E600A64968 /* AHProxySettings.m in Sources */,
 				7B9A21681B9F0F10002539F7 /* DTTimePeriod.m in Sources */,

--- a/App/BitBar/NSString+ANSI.h
+++ b/App/BitBar/NSString+ANSI.h
@@ -1,0 +1,15 @@
+//
+//  NSString+ANSI.h
+//  BitBar
+//
+//  Created by Kent Karlsson on 3/11/16.
+//  Copyright © 2016 Bit Bar. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (ANSI)
+
+- (NSMutableAttributedString*)attributedStringParsingANSICodes;
+
+@end

--- a/App/BitBar/NSString+ANSI.h
+++ b/App/BitBar/NSString+ANSI.h
@@ -10,6 +10,7 @@
 
 @interface NSString (ANSI)
 
+- (BOOL)containsANSICodes;
 - (NSMutableAttributedString*)attributedStringParsingANSICodes;
 
 @end

--- a/App/BitBar/NSString+ANSI.m
+++ b/App/BitBar/NSString+ANSI.m
@@ -1,0 +1,140 @@
+//
+//  NSString+ANSI.m
+//  BitBar
+//
+//  Created by Kent Karlsson on 3/11/16.
+//  Copyright © 2016 Bit Bar. All rights reserved.
+//
+
+#import "Cocoa/Cocoa.h"
+#import "NSString+ANSI.h"
+#import "NSColor+Hex.h"
+
+@implementation NSMutableDictionary (ANSI)
+
+- (NSMutableDictionary*)modifyAttributesForANSICodes:(NSString*)codes {
+  BOOL bold = NO;
+  NSFont* font = self[NSFontAttributeName];
+
+  NSArray* codeArray = [codes componentsSeparatedByString:@";"];
+
+  if ([codes isEqualToString:@"0"] || [codes isEqualToString:@""]) {
+    return [NSMutableDictionary.alloc init];
+  }
+
+  for (NSString* codeString in codeArray) {
+    int code = codeString.intValue;
+    switch (code) {
+      case 0:
+        [self removeAllObjects];
+        // remove italic and bold from font here
+        if (font) self[NSFontAttributeName] = font;
+        break;
+
+      case 1:
+      case 22:
+        bold = (code == 1);
+        break;
+
+    // case 3: italic
+    // case 23: italic off
+    // case 4: underlined
+    // case 24: underlined off
+
+      case 30:
+        self[NSForegroundColorAttributeName] = [NSColor colorWithHexColorString:bold ? @"7f7f7f" : @"000000"];
+        break;
+      case 31:
+        self[NSForegroundColorAttributeName] = [NSColor colorWithHexColorString:bold ? @"cd0000" : @"ff0000"];
+        break;
+      case 32:
+        self[NSForegroundColorAttributeName] = [NSColor colorWithHexColorString:bold ? @"00cd00" : @"00ff00"];
+        break;
+      case 33:
+        self[NSForegroundColorAttributeName] = [NSColor colorWithHexColorString:bold ? @"cdcd00" : @"ffff00"];
+        break;
+      case 34:
+        self[NSForegroundColorAttributeName] = [NSColor colorWithHexColorString:bold ? @"0000ee" : @"5c5cff"];
+        break;
+      case 35:
+        self[NSForegroundColorAttributeName] = [NSColor colorWithHexColorString:bold ? @"cd00cd" : @"ff00ff"];
+        break;
+      case 36:
+        self[NSForegroundColorAttributeName] = [NSColor colorWithHexColorString:bold ? @"00cdcd" : @"00ffff"];
+        break;
+      case 37:
+        self[NSForegroundColorAttributeName] = [NSColor colorWithHexColorString:bold ? @"e5e5e5" : @"ffffff"];
+        break;
+
+      case 39:
+        [self removeObjectForKey:NSForegroundColorAttributeName];
+        break;
+
+      case 40:
+        self[NSBackgroundColorAttributeName] = [NSColor colorWithHexColorString:@"7f7f7f"];
+        break;
+      case 41:
+        self[NSBackgroundColorAttributeName] = [NSColor colorWithHexColorString:@"cd0000"];
+        break;
+      case 42:
+        self[NSBackgroundColorAttributeName] = [NSColor colorWithHexColorString:@"00cd00"];
+        break;
+      case 43:
+        self[NSBackgroundColorAttributeName] = [NSColor colorWithHexColorString:@"cdcd00"];
+        break;
+      case 44:
+        self[NSBackgroundColorAttributeName] = [NSColor colorWithHexColorString:@"0000ee"];
+        break;
+      case 45:
+        self[NSBackgroundColorAttributeName] = [NSColor colorWithHexColorString:@"cd00cd"];
+        break;
+      case 46:
+        self[NSBackgroundColorAttributeName] = [NSColor colorWithHexColorString:@"00cdcd"];
+        break;
+      case 47:
+        self[NSBackgroundColorAttributeName] = [NSColor colorWithHexColorString:@"e5e5e5"];
+        break;
+
+      case 49:
+        [self removeObjectForKey:NSBackgroundColorAttributeName];
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  return self;
+}
+
+@end
+
+@implementation NSString (ANSI)
+
+- (NSMutableAttributedString*)attributedStringParsingANSICodes {
+  NSMutableAttributedString* result = [[NSMutableAttributedString alloc] init];
+
+  NSMutableDictionary* attributes = [NSMutableDictionary.alloc init];
+  NSArray* parts = [self componentsSeparatedByString:@"\033["];
+  [result appendAttributedString:[NSAttributedString.alloc initWithString:parts.firstObject attributes:nil]];
+  
+  for (NSString* part in [parts subarrayWithRange:NSMakeRange(1, parts.count - 1)]) {
+    if (part.length == 0)
+      continue;
+
+    NSArray* sequence = [part componentsSeparatedByString:@"m"];
+    NSString* text = sequence.lastObject;
+
+    if (sequence.count < 2) {
+      [result appendAttributedString:[NSAttributedString.alloc initWithString:text attributes:attributes]];
+    } else if (sequence.count >= 2) {
+      text = [[sequence subarrayWithRange:NSMakeRange(1, sequence.count - 1)] componentsJoinedByString:@"m"];
+      [attributes modifyAttributesForANSICodes:sequence[0]];
+      [result appendAttributedString:[NSAttributedString.alloc initWithString:text attributes:attributes]];
+    }
+  }
+
+  return result;
+}
+
+@end

--- a/App/BitBar/NSString+ANSI.m
+++ b/App/BitBar/NSString+ANSI.m
@@ -107,6 +107,10 @@
 
 @implementation NSString (ANSI)
 
+- (BOOL)containsANSICodes {
+  return [self containsString:@"\033["];
+}
+
 - (NSMutableAttributedString*)attributedStringParsingANSICodes {
   NSMutableAttributedString* result = [[NSMutableAttributedString alloc] init];
 

--- a/App/BitBar/NSString+ANSI.m
+++ b/App/BitBar/NSString+ANSI.m
@@ -18,10 +18,6 @@
 
   NSArray* codeArray = [codes componentsSeparatedByString:@";"];
 
-  if ([codes isEqualToString:@"0"] || [codes isEqualToString:@""]) {
-    return [NSMutableDictionary.alloc init];
-  }
-
   for (NSString* codeString in codeArray) {
     int code = codeString.intValue;
     switch (code) {

--- a/App/BitBar/Plugin.h
+++ b/App/BitBar/Plugin.h
@@ -29,7 +29,7 @@
 - initWithManager:(PluginManager*)manager;
 - (void) close;
 
-
+- (NSMenuItem*) buildMenuItemForLine:(NSString *)line;
 - (NSMenuItem*) buildMenuItemWithParams:(NSDictionary *)params;
 - (void) rebuildMenuForStatusItem:(NSStatusItem*)statusItem;
 - (void) addAdditionalMenuItems:(NSMenu *)menu;
@@ -43,5 +43,6 @@
 
 // actions
 - (void)changePluginsDirectorySelected:(id)sender;
+
 
 @end

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -80,7 +80,8 @@
     item.representedObject = params;
     [item setTarget:self];
   }
-  if (params[@"font"] || params[@"size"] || params[@"color"] || params[@"ansi"])
+  BOOL parseANSI = [fullTitle containsANSICodes] && ![[params[@"ansi"] lowercaseString] isEqualToString:@"false"];
+  if (params[@"font"] || params[@"size"] || params[@"color"] || parseANSI)
     item.attributedTitle = [self attributedTitleWithParams:params];
   
   if (params[@"alternate"]) {
@@ -125,7 +126,8 @@
   }
 
   NSDictionary* attributes = @{NSFontAttributeName: font, NSBaselineOffsetAttributeName : @1};
-  if ([[params[@"ansi"] lowercaseString] isEqualToString:@"true"]) {
+  BOOL parseANSI = [fullTitle containsANSICodes] && ![[params[@"ansi"] lowercaseString] isEqualToString:@"false"];
+  if (parseANSI) {
     NSMutableAttributedString * attributedTitle = [title attributedStringParsingANSICodes];
     [attributedTitle addAttributes:attributes range:NSMakeRange(0, attributedTitle.length)];
     return attributedTitle;

--- a/App/BitBarTests/PluginTest.m
+++ b/App/BitBarTests/PluginTest.m
@@ -287,7 +287,25 @@
   itemCount += 3;
 #endif  
   XCTAssertEqual(itemCount, [[p.statusItem.menu itemArray] count]);
-  
+}
+
+- (void)testParameterANSI {
+  PluginManager *manager = [PluginManager testManager];
+  Plugin *p = [Plugin.alloc initWithManager:manager];
+
+  NSString* helloWorld = @"\033[1;31mH\033[0mello \033[32mW\033[0morld";
+
+  p.content = helloWorld;
+  XCTAssert([p.titleLines[0] isEqualToString:helloWorld]); // unchanged
+
+  NSMenuItem* item = [p buildMenuItemForLine:[NSString stringWithFormat:@"%@ | ansi=true", helloWorld]];
+  XCTAssertEqual(item.title.length, 11);
+  NSDictionary *hAttr, *wAttr, *nAttr;
+  hAttr = [item.attributedTitle attributesAtIndex:0 effectiveRange:nil]; // H
+  nAttr = [item.attributedTitle attributesAtIndex:1 effectiveRange:nil]; // space
+  wAttr = [item.attributedTitle attributesAtIndex:6 effectiveRange:nil]; // W
+  XCTAssertNotEqual(hAttr[NSForegroundColorAttributeName], wAttr[NSForegroundColorAttributeName]); // different colors
+  XCTAssertNil(nAttr[NSForegroundColorAttributeName]); // no color
 }
 
 - (void)testEmoji {

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ If you want to contribute, please send us a pull request and we'll add it to our
     * `templateImage=..` set an image for this item. The image data must be passed as base64 encoded string and should consist of only black and clear pixels. The alpha channel in the image can be used to adjust the opacity of black content, however. This is the recommended way to set an image for the statusbar. The imageformat can be any of the formats supported by Mac OS X
     * `image=..` set an image for this item. The image data must be passed as base64 encoded string. The imageformat can be any of the formats supported by Mac OS X
     * `emojize=false` will disable parsing of github style `:mushroom:` into :mushroom:
+    * `ansi=true` to parse ansi color codes in the text.
 
 ### Metadata
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If you want to contribute, please send us a pull request and we'll add it to our
     * `templateImage=..` set an image for this item. The image data must be passed as base64 encoded string and should consist of only black and clear pixels. The alpha channel in the image can be used to adjust the opacity of black content, however. This is the recommended way to set an image for the statusbar. The imageformat can be any of the formats supported by Mac OS X
     * `image=..` set an image for this item. The image data must be passed as base64 encoded string. The imageformat can be any of the formats supported by Mac OS X
     * `emojize=false` will disable parsing of github style `:mushroom:` into :mushroom:
-    * `ansi=true` to parse ansi color codes in the text.
+    * `ansi=false` turns off parsing of ANSI codes.
 
 ### Metadata
 


### PR DESCRIPTION
Could also be implemented as always-on, instead of triggered by `ansi=true`

Relates #137 

Test Script:
```
#!/bin/bash

echo -e "\033[34mA\033[32mN\033[31mS\033[33mI\033[0m | ansi=true"
echo "---"

T='gYw'   # The test text
echo -e "                 40m     41m     42m     43m\
     44m     45m     46m     47m | ansi=true font=courier trim=false";

for FGs in '    m' '   1m' '  30m' '1;30m' '  31m' '1;31m' '  32m' \
           '1;32m' '  33m' '1;33m' '  34m' '1;34m' '  35m' '1;35m' \
           '  36m' '1;36m' '  37m' '1;37m';
  do FG=${FGs// /}
  echo -en " $FGs \033[$FG  $T  "
  for BG in 40m 41m 42m 43m 44m 45m 46m 47m;
    do echo -en "$EINS \033[$FG\033[$BG  $T  \033[0m";
  done
  echo " | ansi=true font=courier trim=false";
done
echo
```