### PR TITLE
Fix Plugin memory leak causing extra launches

### DIFF
--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -70,6 +70,7 @@
 }
 
 -(BOOL)refresh {
+  [self.statusItem setTitle:@"…"];
   [self.lineCycleTimer invalidate];
   self.lineCycleTimer = nil;
   [self.refreshTimer invalidate];

--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -218,15 +218,8 @@
 }
 
 - (void) reset {
-  
-  // remove all status items
   Plugin *plugin;
-  for (plugin in _plugins) [self.statusBar removeStatusItem:plugin.statusItem];
-  
-  _plugins = nil;
-  [self.statusBar removeStatusItem:self.defaultStatusItem];
-  [self setupAllPlugins];
-  
+  for (plugin in _plugins) [plugin refresh];
 }
 
 - (void) clearPathAndReset {
@@ -259,7 +252,6 @@
       
       [plugin setPath:[self.path stringByAppendingPathComponent:file]];
       [plugin setName:file];
-      [plugin.statusItem setTitle:@"…"];
       
       [plugins addObject:plugin];
       


### PR DESCRIPTION
Every time a refresh occurred a new instance of a Plugin would be
created, with old instances being set to nil. The intention must have
been for ARC to clean it up, but somewhere an extra reference was
hodling on. The strong properties in ExecutablePlugin.h were suspect, as
well as the behavior of the repeating NSTimers in threads that
indefinietly spun up new dispatch_async calls.

I didn't try to find how to make that all work. Instead, I stopped the
PluginManager from creating new plugins every time refresh is called by
the user, which seemed needless. Now, plugins are only ever created
once, and user refresh requests just call the refresh method of each 
known plugin.

One side effect of this is that BitBar will need to be restarted in
order for it to pick up new plugins, but it simplifies the logic a lot.
A potential work around for that might be to just listen for file system
changes on the plugin directory and load the ones that are added.