### PR TITLE
Quick fix for memory leak causing extra runs

### DIFF
--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -77,6 +77,11 @@
     
   // execute command
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,0),  ^{
+    // don't scheudle any further runs if this plugin isn't in the list of known plugins
+    if(![[self.manager plugins] containsObject:self]){
+      return;
+    }
+
     [self refreshContentByExecutingCommand];
     dispatch_sync(dispatch_get_main_queue(), ^{
       

--- a/App/BitBarTests/PluginTest.m
+++ b/App/BitBarTests/PluginTest.m
@@ -217,6 +217,7 @@
   
   PluginManager *manager = [PluginManager testManager];
   ExecutablePlugin *p = [ExecutablePlugin.alloc initWithManager:manager];
+  [manager setPlugins:@[p]];
 
   p.name = @"three.7d.sh";
   p.path = [[PluginManager pluginPath] stringByAppendingPathComponent:p.name];
@@ -234,6 +235,7 @@
   
   PluginManager *manager = [PluginManager testManager];
   ExecutablePlugin *p = [ExecutablePlugin.alloc initWithManager:manager];
+  [manager setPlugins:@[p]];
 
   p.name = @"three.7d.sh";
   p.path = [[PluginManager pluginPath] stringByAppendingPathComponent:p.name];


### PR DESCRIPTION
This addresses https://github.com/matryer/bitbar/issues/195

This is a slightly hacky fix for what looks like a memory leak issue
where plugins keep refreshing bitbar because they never get deallcoated,
regardless of setting all known references to them to `nil`.

This change will cease any further scheduling jobs in plugins if that
plugin is not in the list of plugins known to the PluginManager.