### PR TITLE
Fix for #195

### DIFF
--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -80,35 +80,45 @@
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,0),  ^{
     [weakSelf refreshContentByExecutingCommand];
     dispatch_sync(dispatch_get_main_queue(), ^{
-
-      weakSelf.lastUpdated = NSDate.new;
-
-      [weakSelf rebuildMenuForStatusItem:weakSelf.statusItem];
-
-      // reset the current line
-      weakSelf.currentLine = -1;
-
-      // update the status item
-      [weakSelf cycleLines];
-
-      // sort out multi-line cycler
-      if (weakSelf.isMultiline) {
-
-        // start the timer to keep cycling lines
-        weakSelf.lineCycleTimer = [NSTimer scheduledTimerWithTimeInterval:weakSelf.cycleLinesIntervalSeconds target:weakSelf selector:@selector(cycleLines) userInfo:nil repeats:YES];
-
+      if (weakSelf) {
+        __strong ExecutablePlugin* strongSelf = weakSelf;
+        
+        strongSelf.lastUpdated = NSDate.new;
+        
+        [strongSelf rebuildMenuForStatusItem:strongSelf.statusItem];
+        
+        // reset the current line
+        strongSelf.currentLine = -1;
+        
+        // update the status item
+        [strongSelf cycleLines];
+        
+        // sort out multi-line cycler
+        if (strongSelf.isMultiline) {
+          
+          // start the timer to keep cycling lines
+          strongSelf.lineCycleTimer = [NSTimer scheduledTimerWithTimeInterval:strongSelf.cycleLinesIntervalSeconds target:strongSelf selector:@selector(cycleLines) userInfo:nil repeats:YES];
+          
+        }
+        
+        // tell the manager this plugin has updated
+        [strongSelf.manager pluginDidUdpdateItself:strongSelf];
+        
+        // strongSelf next refresh
+        strongSelf.refreshTimer = [NSTimer scheduledTimerWithTimeInterval:[strongSelf.refreshIntervalSeconds doubleValue] target:strongSelf selector:@selector(refresh) userInfo:nil repeats:NO];
       }
-
-      // tell the manager this plugin has updated
-      [weakSelf.manager pluginDidUdpdateItself:weakSelf];
-
-      // schedule next refresh
-      _refreshTimer = [NSTimer scheduledTimerWithTimeInterval:[weakSelf.refreshIntervalSeconds doubleValue] target:weakSelf selector:@selector(refresh) userInfo:nil repeats:NO];
 
     });
   });
 
   return YES;
+}
+
+- (void) close {
+  [self.lineCycleTimer invalidate];
+  self.lineCycleTimer = nil;
+  [self.refreshTimer invalidate];
+  self.refreshTimer = nil;
 }
 
 

--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -78,37 +78,36 @@
 
   // execute command
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,0),  ^{
-    [weakSelf refreshContentByExecutingCommand];
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      if (weakSelf) {
-        __strong ExecutablePlugin* strongSelf = weakSelf;
-        
-        strongSelf.lastUpdated = NSDate.new;
-        
-        [strongSelf rebuildMenuForStatusItem:strongSelf.statusItem];
-        
-        // reset the current line
-        strongSelf.currentLine = -1;
-        
-        // update the status item
-        [strongSelf cycleLines];
-        
-        // sort out multi-line cycler
-        if (strongSelf.isMultiline) {
+    if (weakSelf) {
+      __strong ExecutablePlugin* strongSelf = weakSelf;
+      [strongSelf refreshContentByExecutingCommand];
+      dispatch_sync(dispatch_get_main_queue(), ^{
           
-          // start the timer to keep cycling lines
-          strongSelf.lineCycleTimer = [NSTimer scheduledTimerWithTimeInterval:strongSelf.cycleLinesIntervalSeconds target:strongSelf selector:@selector(cycleLines) userInfo:nil repeats:YES];
+          strongSelf.lastUpdated = NSDate.new;
           
-        }
-        
-        // tell the manager this plugin has updated
-        [strongSelf.manager pluginDidUdpdateItself:strongSelf];
-        
-        // strongSelf next refresh
-        strongSelf.refreshTimer = [NSTimer scheduledTimerWithTimeInterval:[strongSelf.refreshIntervalSeconds doubleValue] target:strongSelf selector:@selector(refresh) userInfo:nil repeats:NO];
-      }
-
-    });
+          [strongSelf rebuildMenuForStatusItem:strongSelf.statusItem];
+          
+          // reset the current line
+          strongSelf.currentLine = -1;
+          
+          // update the status item
+          [strongSelf cycleLines];
+          
+          // sort out multi-line cycler
+          if (strongSelf.isMultiline) {
+            
+            // start the timer to keep cycling lines
+            strongSelf.lineCycleTimer = [NSTimer scheduledTimerWithTimeInterval:strongSelf.cycleLinesIntervalSeconds target:strongSelf selector:@selector(cycleLines) userInfo:nil repeats:YES];
+            
+          }
+          
+          // tell the manager this plugin has updated
+          [strongSelf.manager pluginDidUdpdateItself:strongSelf];
+          
+          // strongSelf next refresh
+          strongSelf.refreshTimer = [NSTimer scheduledTimerWithTimeInterval:[strongSelf.refreshIntervalSeconds doubleValue] target:strongSelf selector:@selector(refresh) userInfo:nil repeats:NO];
+      });
+    }
   });
 
   return YES;

--- a/App/BitBar/Plugin.h
+++ b/App/BitBar/Plugin.h
@@ -21,12 +21,13 @@
 @property (nonatomic)       NSNumber *refreshIntervalSeconds;
 @property (nonatomic)     NSMenuItem *lastUpdatedMenuItem;
 @property (nonatomic)         NSDate *lastUpdated;
-@property (readonly)   PluginManager *manager;
+@property (unsafe_unretained, readonly)   PluginManager *manager;
 
 // UI
 @property (nonatomic) NSStatusItem *statusItem;
 
 - initWithManager:(PluginManager*)manager;
+- (void) close;
 
 
 - (NSMenuItem*) buildMenuItemWithParams:(NSDictionary *)params;

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -342,6 +342,9 @@
   return YES;
 }
 
+- (void) close {
+}
+
 - (NSString*) lastUpdatedString { return [self.lastUpdated timeAgoSinceNow].lowercaseString; }
 
 - (void) cycleLines {

--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -220,8 +220,10 @@
 - (void) reset {
   
   // remove all status items
-  Plugin *plugin;
-  for (plugin in _plugins) [self.statusBar removeStatusItem:plugin.statusItem];
+  for (Plugin *plugin in _plugins) {
+   [self.statusBar removeStatusItem:plugin.statusItem];
+   [plugin close];
+  }
   
   _plugins = nil;
   [self.statusBar removeStatusItem:self.defaultStatusItem];


### PR DESCRIPTION
This should really fix #195.  Credit to @naddeoa for getting me down the right path.  This should fix all issues with retain
cycles.  I've also implemented appropriate weak -> strong casting to make sure that we don't lose the object half way through
a block.  With this, the sample cpu.sh script only ever fires 1 time no matter how many times you refresh all plugins.

This code implements a `close` method on Plugin objects that can be expanded in the future for other Plugin types (if other
types are implemented.)

Supercedes #276 & #277.