### PR TITLE
Update $BitBarDarkMode when OS's interface style was changed

### DIFF
--- a/App/BitBar/PluginManager.h
+++ b/App/BitBar/PluginManager.h
@@ -15,7 +15,7 @@
 @property (nonatomic)        NSArray *plugins;
 @property (nonatomic)    NSStatusBar *statusBar;
 @property (nonatomic)   NSStatusItem *defaultStatusItem;
-@property (nonatomic)   NSDictionary *environment;
+@property (nonatomic, readonly) NSDictionary<NSString *, NSString *> *environment;
 
 - initWithPluginPath:(NSString *)path;
 
@@ -28,5 +28,6 @@
 - (void) addHelperItemsToMenu:(NSMenu*)menu asSubMenu:(BOOL)submenu;
 
 - (void) pluginDidUdpdateItself:(Plugin*)plugin;
+- (void) updateEnvironment;
 
 @end


### PR DESCRIPTION
Fixes #470 
Fixes #377

With this PR, `PluginManager`'s `environment` will be updated every time when the OS's theme (Dark/Light) was changed.